### PR TITLE
docs: fix typo in vanillajs.mdx

### DIFF
--- a/quickstarts/vanillajs.mdx
+++ b/quickstarts/vanillajs.mdx
@@ -154,7 +154,7 @@ We have already used the CDN to get the notification center component and we alr
 
     <script>
       // here you can attach any callbacks, interact with the web component API
-      // You can also move this to a seperate js file and have all the callbacks and other logic there
+      // You can also move this to a separate js file and have all the callbacks and other logic there
       let nc =document.getElementsByTagName('notification-center-component')[0];
       nc.onLoad = () => console.log('hello world!');
     </script>
@@ -163,7 +163,7 @@ We have already used the CDN to get the notification center component and we alr
 
 ```
 
-You can add all the logic you want to add to the `script` element at the bottom or move it all into a seperate JavaScript file (don't forger to link to the JavaScript file in this case).
+You can add all the logic you want to add to the `script` element at the bottom or move it all into a separate JavaScript file (don't forger to link to the JavaScript file in this case).
 
 Here's an example of such an HTML file:
 


### PR DESCRIPTION
seperate -> separate