### PR TITLE
Updated docs for PHP quickstart

### DIFF
--- a/quickstarts/php.mdx
+++ b/quickstarts/php.mdx
@@ -22,7 +22,7 @@ The [PHP SDK](http://github.com/novuhq/novu-php) provides a fluent and express
 Now install the Novu PHP SDK by running the following command in your terminal:
 
 ```bash
-composer install unicodeveloper/novu
+composer require unicodeveloper/novu
 
 ```
 

--- a/quickstarts/php.mdx
+++ b/quickstarts/php.mdx
@@ -142,7 +142,7 @@ php index.php
 
 You should see the subscriber on your Novu dashboard.
 
-!https://res.cloudinary.com/dxc6bnman/image/upload/f_auto,q_auto/v1685466979/guides/Screenshot_2023-05-14_at_11.06.38_ugvmc0.png
+<Frame caption="Subscribers list shows newly added subscriber"><img src="https://res.cloudinary.com/dxc6bnman/image/upload/f_auto,q_auto/v1685466979/guides/Screenshot_2023-05-14_at_11.06.38_ugvmc0.png" /> </Frame>
 
 I’d like to publicly announce that `abc@gmail.com` is a random unlikely email your users will have. To update this to an alternative email, you can call the `updateSubscriber` method like so:
 


### PR DESCRIPTION
- Updated the command required to install the PHP SDK
![image](https://github.com/novuhq/docs/assets/70463535/ac419901-8914-4d3e-828c-637e1b005d8e)

- Fixed the screenshot displaying URL and not the image itself
![image](https://github.com/novuhq/docs/assets/70463535/730a1715-bc30-49d8-b3a7-fe32f28d7f3e)

