### PR TITLE
fix: typo `notificationTemplateId` -> `notificationWorkflowId`

### DIFF
--- a/quickstarts/nodejs.mdx
+++ b/quickstarts/nodejs.mdx
@@ -138,7 +138,7 @@ Copy and paste the following code into your app to trigger a notification:
 ```jsx
 const notificationWorkflowId = 'first-email';
 
-novu.trigger(notificationTemplateId, {
+novu.trigger(notificationWorkflowId, {
   to: {
     subscriberId: '7789',
   },


### PR DESCRIPTION
Fixed a typo where an undefined `notificationTemplateId` was referenced instead of the const `notificationWorkflowId`.