### PR TITLE
Mailtrap docs

### DIFF
--- a/channels-and-providers/email/mailtrap.mdx
+++ b/channels-and-providers/email/mailtrap.mdx
@@ -13,9 +13,9 @@ To use the Mailtrap provider in the email channel, you will need to create a Mai
 
 To generate a new API key in Mailtrap, you can follow these steps:
 
-- [Sign Up](https://mailtrap.io/register/signup) or [Login](https://mailtrap.io/signin) to your Mailtrap account.
+- [Sign Up](https://mailtrap.io/register/signup) or [Log in](https://mailtrap.io/signin) to your Mailtrap account.
 - Click on the **Email Sending** link on the sidebar, and then click the "Sending Domains" link that pops up from the available options.
-- On the [Sending Domains](https://mailtrap.io/sending/domains) page, type your domain name and confirm with the `Add Your Domain button`. Then, proceed to copy DNS records Mailtrap provides to your domain’s DNS. 
+- On the [Sending Domains](https://mailtrap.io/sending/domains) page, type your domain name and confirm with the `Add Your Domain` button. Then, proceed to copy DNS records Mailtrap provides to your domain’s DNS. 
 - Go to [API Keys](https://mailtrap.io/api-tokens) page and copy token with `Domain Admin` access level for your registered domain.
 
 # Authenticating your Sender Identity

--- a/channels-and-providers/email/mailtrap.mdx
+++ b/channels-and-providers/email/mailtrap.mdx
@@ -8,3 +8,26 @@ You can use the [Mailtrap](https://mailtrap.io/email-sending/) provider to send 
 # Getting Started
 
 To use the Mailtrap provider in the email channel, you will need to create a Mailtrap account and add your API key to the Mailtrap integration on the Novu platform.
+
+# Generating an API Key
+
+To generate a new API key in Mailtrap, you can follow these steps:
+
+- [Sign Up](https://mailtrap.io/register/signup) or [Login](https://mailtrap.io/signin) to your Mailtrap account.
+- Click on the **Email Sending** link on the sidebar, and then click the "Sending Domains" link that pops up from the available options.
+- On the [Sending Domains](https://mailtrap.io/sending/domains) page, type your domain name and confirm with the `Add Your Domain button`. Then, proceed to copy DNS records Mailtrap provides to your domain’s DNS. 
+- Go to [API Keys](https://mailtrap.io/api-tokens) page and copy token with `Domain Admin` access level for your registered domain.
+
+# Authenticating your Sender Identity
+
+Before you can send emails, you will need to [verify your sending domain ownership](https://help.mailtrap.io/article/69-sending-domain-setup). Mailtrap rejects sending emails from unverified domains to prevent spam and email fraud.
+
+# Creating a Mailtrap integration with Novu
+
+- Visit the [Integrations store](https://web.novu.co/integrations) on the Novu web dashboard.
+- Locate Mailtrap and click on the **Connect** button.
+- Enter your Mailtrap API Key.
+- Fill in the `From email address` field using the authenticated email from the previous step.
+- Click on the `Disabled` button and mark it as `Active`.
+- Click on the **Connect** button.
+- You should now be able to send notifications through Mailtrap using Novu.

--- a/channels-and-providers/email/mailtrap.mdx
+++ b/channels-and-providers/email/mailtrap.mdx
@@ -1,0 +1,10 @@
+---
+title: 'Mailtrap'
+description: 'Learn how to use the Mailtrap provider to send email notifications using Novu'
+---
+
+You can use the [Mailtrap](https://mailtrap.io/email-sending/) provider to send transactional emails to your customers using the Novu Platform with a single API to create multi-channel experiences.
+
+# Getting Started
+
+To use the Mailtrap provider in the email channel, you will need to create a Mailtrap account and add your API key to the Mailtrap integration on the Novu platform.

--- a/mint.json
+++ b/mint.json
@@ -229,6 +229,7 @@
             "channels-and-providers/email/mailersend",
             "channels-and-providers/email/mailgun",
             "channels-and-providers/email/mailjet",
+            "channels-and-providers/email/mailtrap",
             "channels-and-providers/email/mandrill",
             "channels-and-providers/email/netcore",
             "channels-and-providers/email/outlook365",


### PR DESCRIPTION
Documentation for Mailtrap email provider introduced in my PR https://github.com/novuhq/novu/pull/4328

Provider's links for reference:
- [Homepage](https://mailtrap.io/)
- [Get Started - Mailtrap Email Sending official docs](https://help.mailtrap.io/article/110-get-started-mailtrap-email-sending)
- [Sending Domain Setup official docs](https://help.mailtrap.io/article/69-sending-domain-setup)

![Screenshot](https://github.com/novuhq/docs/assets/43048524/4d3e8e5f-6370-4c21-b048-863cebcd6316)
