### PR TITLE
Api docs Redirect

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -285,8 +285,7 @@
       "group": "Self-hosting Novu",
       "pages": [
         "self-hosting-novu/introduction",
-        "self-hosting-novu/deploy-with-docker",
-        "self-hosting-novu/kubernetes"
+        "self-hosting-novu/deploy-with-docker"
       ]
     },
     {

--- a/mint.json
+++ b/mint.json
@@ -285,7 +285,8 @@
       "group": "Self-hosting Novu",
       "pages": [
         "self-hosting-novu/introduction",
-        "self-hosting-novu/deploy-with-docker"
+        "self-hosting-novu/deploy-with-docker",
+        "self-hosting-novu/kubernetes"
       ]
     },
     {
@@ -549,6 +550,12 @@
     }
   ],
   "backgroundImage": "/background.png",
+  "redirects": [
+    {
+      "source": "/api/client-libraries",
+      "destination": "/sdks/introduction"
+    }
+  ],
   "footerSocials": {
     "twitter": "https://twitter.com/novuhq",
     "github": "https://github.com/novuhq",
@@ -566,7 +573,7 @@
     "intercom": "fqe0apnx"
   },
   "versions": [
-    "v0.19.0", 
+    "v0.19.0",
     "v0.18.0"
   ]
 }


### PR DESCRIPTION
Currently users are getting a 404 when tring to go to /api/client-libraries as noted https://github.com/novuhq/novu/issues/4371

However by adding a simple redirect, the link will still work while we look to switch the reference.