### PR TITLE
fix link for reference-to-add-provider

### DIFF
--- a/community/add-a-new-provider.mdx
+++ b/community/add-a-new-provider.mdx
@@ -122,7 +122,7 @@ import { ExampleProviderEmailProvider } from './example-provider.provider';
 test('should trigger example-provider library correctly', async () => {});
 ```
 
-<Info> Add the provider's SDK as a dependency in the provider's package.json file. Run `pnpm run setup:project` to build all dependencies again. Use this new sdk method to complete the provider's `sendMessage` function. Check the `[reference links for adding new providers](#reference-for-adding-new-providers)` section for each channel's provider example. </Info>
+<Info> Add the provider's SDK as a dependency in the provider's package.json file. Run `pnpm run setup:project` to build all dependencies again. Use this new sdk method to complete the provider's `sendMessage` function. Check the **[reference links for adding new providers](#reference-for-adding-new-providers)** section for each channel's provider example. </Info>
 
 ### Add provider logos
 


### PR DESCRIPTION
The link was enclosed in `` so it was not working. Also made it serves almost the same purpose

Before the fix
![Screenshot_985](https://github.com/novuhq/docs/assets/89470104/525a8c27-0ad3-43df-91cb-d62f240adb40)
