### PR TITLE
Adding the missing icons to SDK Navigation Bar

### DIFF
--- a/sdks/angular.mdx
+++ b/sdks/angular.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Angular Component"
 description: "Novu’s Angular library provides an Angular component wrapper over the Notification Center Web that you can use to integrate the notification center into your Angular application. "
+icon: 'angular'
 ---
 
 

--- a/sdks/dotnet.mdx
+++ b/sdks/dotnet.mdx
@@ -1,6 +1,7 @@
 ---
 title: "C#/.NET"
 description: "Connect a .NET application to Novu"
+icon: 'square-5'
 ---
 
 Novu's .NET SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your C#/.NET application.

--- a/sdks/go.mdx
+++ b/sdks/go.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Go"
 description: "Connect a Go application to Novu"
+icon: 'golang'
 ---
 
 

--- a/sdks/headless-javascript-service.mdx
+++ b/sdks/headless-javascript-service.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Headless JavaScript Service"
 description: "Novu’s headless library provides users with a lightweight, completely unstyled, zero UI solution for integrating notification functionality into their web applications."
+icon: 'js'
 ---
 
 [Explore the source code on GitHub](https://github.com/novuhq/novu/tree/next/packages/headless)

--- a/sdks/iframe-embed.mdx
+++ b/sdks/iframe-embed.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Iframe Embed"
 description: "Embed a real-time notification center inside an iframe using our embedded script."
+icon: 'frame'
 ---
 
 If you are using a (currently) unsupported client framework, you can use our embedded script. 

--- a/sdks/java.mdx
+++ b/sdks/java.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Java"
 description: "Connect a Java application to Novu"
+icon: 'java'
 ---
 
 Novu's Java SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your Java application.

--- a/sdks/kotlin.mdx
+++ b/sdks/kotlin.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Kotlin"
 description: "Connect a Kotlin application to Novu"
+icon: 'kotlin'
 ---
 
 Novu's Kotlin SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your Kotlin application.

--- a/sdks/laravel.mdx
+++ b/sdks/laravel.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Laravel"
 description: "Connect a Laravel application to Novu"
+icon: 'laravel'
 ---
 
 

--- a/sdks/nodejs.mdx
+++ b/sdks/nodejs.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Node.js"
 description: "Connect a Node.js application to Novu"
+icon: 'node'
 ---
 
 Novu's Node.js SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your Node.js application.

--- a/sdks/php.mdx
+++ b/sdks/php.mdx
@@ -1,6 +1,7 @@
 ---
 title: "PHP"
 description: "Connect a PHP application to Novu"
+icon: 'php'
 ---
 
 Novu's PHP SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your PHP application.

--- a/sdks/python.mdx
+++ b/sdks/python.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Python"
 description: "Connect a Python application to Novu"
+icon: 'python'
 ---
 
 Novu's Python SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your Python application.

--- a/sdks/react.mdx
+++ b/sdks/react.mdx
@@ -1,6 +1,7 @@
 ---
 title: "React Component"
 description: "Novu’s React library provides a fully functional and embeddable notification center component with real-time updates that you can drop into your React application."
+icon: 'react'
 ---
 
 [Explore the source code on GitHub](https://github.com/novuhq/novu/tree/next/packages/notification-center)

--- a/sdks/ruby.mdx
+++ b/sdks/ruby.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Ruby"
 description: "Connect a Ruby application to Novu."
+icon: 'ruby'
 ---
 
 Novu's Ruby SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your Ruby application.

--- a/sdks/vue.mdx
+++ b/sdks/vue.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Vue Component"
 description: "Novu’s Vue library provides a Vue component wrapper over the Notification Center Web that you can use to integrate the notification center into your Vue application. "
+icon: 'vuejs'
 ---
 
 

--- a/sdks/web-component.mdx
+++ b/sdks/web-component.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Web Component"
 description: "Novu’s Web Component library provides a fully functional and embeddable notification center widget with real-time updates that you can drop into any web application."
+icon: 'square-js'
 ---
 
 [Explore the source code on GitHub](https://github.com/novuhq/novu/tree/next/packages/notification-center)


### PR DESCRIPTION
This PR closes #154 by adding the icons to SDK Navigation bar create uniformity between UX across pages. The icons for ruby and kotlin wont be visible due to svg however i have added a icon space so that alignment with other headers are maintained.

