### PR TITLE
docs: fix typo in additional-resources/rate-limits.mdx

### DIFF
--- a/additional-resources/rate-limits.mdx
+++ b/additional-resources/rate-limits.mdx
@@ -93,7 +93,7 @@ Batch endpoints are limited in such a way to be the same or more throughput then
 1. **Triggers:** ( if used fully ~1 million per hour)
     - Free: 20 per minute
     - Paid: 200 per minute
-2. **Data: ** ( if used fullly ~.5 million per hour)
+2. **Data: ** ( if used fully ~.5 million per hour)
     - Free: 5 per minute
     - Paid: 10 per minute
 3. **Management:** ( if used fully ~.1 million per hour)


### PR DESCRIPTION
fullly -> fully