### PR TITLE
docs: fix typo in quickstarts/react.mdx

### DIFF
--- a/quickstarts/react.mdx
+++ b/quickstarts/react.mdx
@@ -71,7 +71,7 @@ I'll briefly explain the function of each label in the image above:
 - **7-Editor**: You can add text that you want to be displayed in each notification item. Additionally, you can specify custom variables using `{{ }}`. This means you can inject variables from your code into a notification item's text via a payload.
 
 In our case, we'll use the custom variables functionality, as shown below:
-<Frame caption="We're gonna use custom varaibles here"><img src="/images/custom-var-react.png" /> </Frame>
+<Frame caption="We're gonna use custom variables here"><img src="/images/custom-var-react.png" /> </Frame>
 
 Feel free to add only text for now and rename the workflow to quickstart. It automatically creates a slug-like Identifier that will be needed in later steps to trigger a notification.
 

--- a/quickstarts/vue.mdx
+++ b/quickstarts/vue.mdx
@@ -272,7 +272,7 @@ await novu.subscribers.update('132', {
 To trigger a notification, simply run the codesandbox below with the correct credentials.
 
 ```jsx
-// code to trigger a notificaion
+// code to trigger a notification
 ```
 
 `onboarding-in-app` is the workflow identifier we created earlier.


### PR DESCRIPTION
1. notificaion -> notification 
2. varaibles -> variables