### PR TITLE
Fixed issue highlighting the DOTNET/C# code snippet

### DIFF
--- a/sdks/dotnet.mdx
+++ b/sdks/dotnet.mdx
@@ -21,7 +21,7 @@ dotnet add package Novu
 
 ## Usage
 
-```dotnet#
+```dotnet
 using Novu.DTO;
 using Novu.Models;
 using Novu;

--- a/sdks/dotnet.mdx
+++ b/sdks/dotnet.mdx
@@ -1,7 +1,7 @@
 ---
 title: "C#/.NET"
 description: "Connect a .NET application to Novu"
-icon: 'microsoft'
+icon: "microsoft"
 ---
 
 Novu's .NET SDK provides simple, yet comprehensive notification management, and delivery capabilities through multiple channels that you can implement using code that integrates seamlessly with your C#/.NET application.
@@ -10,15 +10,18 @@ Novu's .NET SDK provides simple, yet comprehensive notification management, and 
 
 ## Installation
 
-```javascript
+```dotnet
 dotnet add package Novu
 ```
 
-<Tip> If you're ready to start integrating in your .NET app, jump straight to our [.NET quickstart.](/quickstarts/.NET)</Tip>
+<Tip>
+   If you're ready to start integrating in your .NET app, jump straight to
+  our [.NET quickstart.](/quickstarts/.NET)
+</Tip>
 
-## Usage 
+## Usage
 
-```c#
+```dotnet#
 using Novu.DTO;
 using Novu.Models;
 using Novu;
@@ -64,4 +67,3 @@ if (trigger.TriggerResponsePayloadDto.Acknowledged)
   Console.WriteLine("Trigger has been created.");
 }
 ```
-


### PR DESCRIPTION
## There is issue where the DOTNET/C# code snippet is not highlighted in the SDK's section of server ,while all other code snippets are.

# issue screenshots :
![image](https://github.com/novuhq/docs/assets/82649533/6db53354-fe79-42e6-8945-3a8461e6b4e9)

# FIX screenshot:
![image](https://github.com/novuhq/docs/assets/82649533/fb0a40f2-cdd9-4893-89b7-ec9284f80b08)
