### PR TITLE
docs: fixes typo and link

### DIFF
--- a/content-creation-design/notification-content-creation.mdx
+++ b/content-creation-design/notification-content-creation.mdx
@@ -192,7 +192,7 @@ You can:
 
 ## SMS
 
-When crafting your SMS notification, you can tap into all all the available variables and even add dynamic ones.
+When crafting your SMS notification, you can tap into all the available variables and even add dynamic ones.
 
 <img style={{ borderRadius: "0.5rem" }} src="/images/sms-editor.png" />
 

--- a/getting-started/concepts.mdx
+++ b/getting-started/concepts.mdx
@@ -110,7 +110,7 @@ The digest engine collects multiple trigger events, aggregates them into a singl
 
 ## Layouts
 
-Novu allows the creation of layouts - a specific HTML design or structure to wrap content of email notifications. Layouts can be manipulated and assigned to new or existing workflows within the Novu platform, allowing users to create, manage, and assign these layouts to workflows, so they can be reused to structure the appearance of notifications sent through the platform. [Learn more](/content-creation-design/notification-content-creation)
+Novu allows the creation of layouts - a specific HTML design or structure to wrap content of email notifications. Layouts can be manipulated and assigned to new or existing workflows within the Novu platform, allowing users to create, manage, and assign these layouts to workflows, so they can be reused to structure the appearance of notifications sent through the platform. [Learn more](/content-creation-design/layouts)
 
 ## Tenants
 


### PR DESCRIPTION
- fixes typo in content creation and design/content creation.
**Before**
![Screenshot 2023-10-24 160939](https://github.com/novuhq/docs/assets/76729141/612ae3e1-c431-4c3b-91b0-4eb8940ff2ba)
**After**
![Screenshot 2023-10-24 161020](https://github.com/novuhq/docs/assets/76729141/45ceb121-26a1-46c7-83ad-a4696e2b835a)
- fixes link in getting started/concepts.
The link in the layouts section is about content creation and not layouts. This fix will now take the user to layouts.