### PR TITLE
Change S3 to Object Store

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -292,7 +292,7 @@
       "pages": [
         "self-hosting-novu/introduction",
         "self-hosting-novu/deploy-with-docker",
-        "self-hosting-novu/s3",
+        "self-hosting-novu/object-storage",
         "self-hosting-novu/kubernetes"
       ]
     },

--- a/self-hosting-novu/introduction.mdx
+++ b/self-hosting-novu/introduction.mdx
@@ -4,7 +4,10 @@ description: ''
 icon: 'code'
 ---
 
-Self-hosting Novu involves setting up and maintaining your communication infrastructure using your own servers. While this offers full control and customization, some features which are available only for Novu’s cloud-managed won't be available in a self-hosted environment.
+Self-hosting Novu involves setting up and maintaining your communication infrastructure using your own servers.
+While this offers full control and customization,
+some features which are available only for Novu’s cloud-managed won't be available in a self-hosted environment.
 
-<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://calendly.com/novuhq/novu-meeting?utm_source=novuDocs&utm_page=self-hosting-introduction). 
+<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations,
+    please don't hesitate to [contact our team](https://calendly.com/novuhq/novu-meeting?utm_source=novuDocs&utm_page=self-hosting-introduction).
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>

--- a/self-hosting-novu/object-storage.mdx
+++ b/self-hosting-novu/object-storage.mdx
@@ -1,15 +1,24 @@
 ---
-title: "S3"
+title: "Object Storage (S3, Blob, GCS)"
 description: "Using S3 as a storage backend for your application"
-icon: "aws"
+icon: "object"
 ---
 
 For local development we use [LocalStack.cloud](https://localstack.cloud/). It is utilized as a local emulation of S3 during development.
 
 This might be beneficial for testing and development purposes before transitioning to actual S3 service like in a production environment.
 
-## S3 Configuration
+## AWS S3
 
+### Configuration
+
+AWS S3 requires the following environment variables to be set:
+1. S3_REGION:
+2. S3_LOCAL_STACK (optional): S3 endpoint to connect to, leave blank if your connecting directly to AWS
+3. S3_BUCKET_NAME: Name of the bucket to use
+4. STORAGE_SERVICE: Name of the storage service to use, 'AWS' or 'LOCALSTACK' for S3.
+
+### Bucket Configuration
 In general, access to the S3 bucket is very permissive.
 
 The following process is used to manage access to the S3 bucket.
@@ -233,3 +242,33 @@ resource "aws_iam_role_policy_attachment" "s3" {
 }
 
 ```
+
+## Azure Blob Storage Configuration
+
+### Configuration
+
+Azure Blob Storage requires the following environment variables to be set:
+
+### Required
+1. STORAGE_SERVICE: Name of the storage service to use, 'AZURE' Azure Blob.
+2. AZURE_CONTAINER_NAME: The name of the container in your Azure Storage account that you wish to use for your blob storage.
+3. AZURE_ACCOUNT_NAME: The name of your Azure Storage account. This is used to form the URL at which your blob storage is accessible.
+4. AZURE_ACCOUNT_KEY: The access key for your Azure Storage account. This is used to authenticate requests made against your blob storage.
+5. AZURE_HOST_NAME: The host name of your Azure Storage account . This is used to form the URL at which your blob storage is accessible. [Ref](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-nodejs?tabs=managed-identity%2Croles-azure-portal%2Csign-in-azure-cli#upload-blobs-to-a-container).
+
+### Bucket Configuration
+
+TBD
+
+## Google Cloud Storage Configuration
+
+### Configuration
+
+Google Cloud Storage requires the following environment variables to be set:
+1. GCS_BUCKET_NAME: Name of the bucket to use.
+2. GOOGLE_APPLICATION_CREDENTIALS: Path to the service account key file.
+3. STORAGE_SERVICE: Name of the storage service to use, 'GCS' for Google Cloud Storage.
+
+### Bucket Configuration
+TBD
+


### PR DESCRIPTION
This pr changes the s3 file to object store for self-hosting as we support s3, blob, and gcs in novu.

This had alot of questions as potential customers where thinking that we only support S3.

This PR should be rolled to Prod asap.