### PR TITLE
feat: Added cURL Request Examples for Workflow Groups API in API Reference Documentation

### DIFF
--- a/api-reference/workflow-groups/create-workflow-group.mdx
+++ b/api-reference/workflow-groups/create-workflow-group.mdx
@@ -5,6 +5,14 @@ openapi: post /v1/notification-groups
 <Snippet file="apikey-warning.mdx" />
 
 <RequestExample>
+```bash cURL
+curl --request POST \
+--url https://api.novu.co/v1/notification-groups \
+--header 'Authorization: ApiKey <NOVU_API_KEY>' \
+--header 'Content-Type: application/json' \
+--data '{"name": "insert-name"}'
+```
+
 ```javascript Node.js
 import { Novu, TemplateVariableTypeEnum, FilterPartTypeEnum, StepTypeEnum } from '@novu/node';
 

--- a/api-reference/workflow-groups/delete-workflow-group.mdx
+++ b/api-reference/workflow-groups/delete-workflow-group.mdx
@@ -5,6 +5,12 @@ openapi: delete /v1/notification-groups/{id}
 <Snippet file="apikey-warning.mdx" />
 
 <RequestExample>
+```bash cURL
+curl --request DELETE \
+--url https://api.novu.co/v1/notification-groups/{id} \
+--header 'Authorization: ApiKey <NOVU_API_KEY>'
+```
+
 ```javascript Node.js
 import { Novu, TemplateVariableTypeEnum, FilterPartTypeEnum, StepTypeEnum } from '@novu/node';
 

--- a/api-reference/workflow-groups/get-workflow-group.mdx
+++ b/api-reference/workflow-groups/get-workflow-group.mdx
@@ -5,6 +5,12 @@ openapi: get /v1/notification-groups/{id}
 <Snippet file="apikey-warning.mdx" />
 
 <RequestExample>
+```bash cURL
+curl --request GET \
+--url https://api.novu.co/v1/notification-groups/{id} \
+--header 'Authorization: ApiKey <NOVU_API_KEY>'
+```
+
 ```javascript Node.js
 import { Novu, TemplateVariableTypeEnum, FilterPartTypeEnum, StepTypeEnum } from '@novu/node';
 

--- a/api-reference/workflow-groups/get-workflow-groups.mdx
+++ b/api-reference/workflow-groups/get-workflow-groups.mdx
@@ -5,6 +5,12 @@ openapi: get /v1/notification-groups
 <Snippet file="apikey-warning.mdx" />
 
 <RequestExample>
+```bash cURL
+curl --request GET \
+--url https://api.novu.co/v1/notification-groups \
+--header 'Authorization: ApiKey <NOVU_API_KEY>' \
+```
+
 ```javascript Node.js
 import { Novu, TemplateVariableTypeEnum, FilterPartTypeEnum, StepTypeEnum } from '@novu/node';
 

--- a/api-reference/workflow-groups/update-workflow-group.mdx
+++ b/api-reference/workflow-groups/update-workflow-group.mdx
@@ -5,6 +5,14 @@ openapi: patch /v1/notification-groups/{id}
 <Snippet file="apikey-warning.mdx" />
 
 <RequestExample>
+```bash cURL
+curl --request PATCH \
+--url https://api.novu.co/v1/notification-groups/{id} \
+--header 'Authorization: ApiKey <NOVU_API_KEY>' \
+--header 'Content-Type: application/json' \
+--data '{"name": "insert-new-name"}'
+```
+
 ```javascript Node.js
 import { Novu, TemplateVariableTypeEnum, FilterPartTypeEnum, StepTypeEnum } from '@novu/node';
 


### PR DESCRIPTION
closes #165 

![image](https://github.com/novuhq/docs/assets/83168881/33fe8de3-67e3-4002-a9cc-d119b8ca87e2)

added cURL request examples for:
- [Get workflow groups](https://docs.novu.co/api-reference/workflow-groups/get-workflow-groups)
- [Create workflow group](https://docs.novu.co/api-reference/workflow-groups/create-workflow-group)
- [Get workflow group](https://docs.novu.co/api-reference/workflow-groups/get-workflow-group)
- [Delete workflow group](https://docs.novu.co/api-reference/workflow-groups/delete-workflow-group)
- [Update workflow group](https://docs.novu.co/api-reference/workflow-groups/update-workflow-group)