### PR TITLE
fix(data-migrations): Fix ordering and typo

### DIFF
--- a/additional-resources/data-migrations.mdx
+++ b/additional-resources/data-migrations.mdx
@@ -33,6 +33,6 @@ Below you will find a list of migrations introduced in previous versions of Novu
 | | Secure Flag Fix | `./secure-to-boolean/secure-to-boolean-migration.ts` |
 | [v0.15](https://github.com/novuhq/novu/releases/tag/v0.15.0) | Database TTL | `./expire-at/expire-at.migration.ts` |
 | [v0.12](https://github.com/novuhq/novu/releases/tag/v0.12.0) | Organization Invite Fix | `./normalize-users-email/normalize-users-email.migration.ts` |
+| [v0.9](https://github.com/novuhq/novu/releases/tag/v0.9.0) | Seen/Read Support | `./seen-read-support/seen-read-support.migration.ts` |
 | [v0.8](https://github.com/novuhq/novu/releases/tag/v0.8.0) | Secure Credentials | `./fcm-credentials/fcm-credentials-migration.ts`<br/>`./encrypt-credentials/encrypt-credentials-migration.ts` |
-| [v0.9.0](https://github.com/novuhq/novu/releases/tag/v0.9.0) | Seen/Read Support | `./seen-read-support/seen-read-support.migration.ts` |
 | [v0.4](https://github.com/novuhq/novu/releases/tag/v0.4.0) | Change Promotion | `./changes-migration.ts` |


### PR DESCRIPTION
Small fix to remove the trailing `.0` from `v0.9.0` and order versions chronologically.