### PR TITLE
docs: Update notification-center/vue props documentation

### DIFF
--- a/notification-center/client/vue.mdx
+++ b/notification-center/client/vue.mdx
@@ -95,3 +95,15 @@ You can pass the custom bell button component as the default slot to the `Notif
 
 [CodeSandBox Link 🔗](https://codesandbox.io/p/sandbox/novu-vue-in-app-88p8vx)
 
+
+## Props
+
+The `NotificationCenterComponent` accepts the same set of props as the [Web Component](./web-component#properties).
+
+It also accepts an extra prop
+
+
+| Prop                    | Type                                                                           | Description                                                                                                                                                                                                                                                                                                                                                                     |
+| ----------------------- | ------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| triggers                | string[]                                                                       | This is an Array of events that controls the underlying popper component's trigger. [Read more here](https://floating-vue.starpad.dev/api/#triggers)
+


### PR DESCRIPTION
### What change does this PR introduce?

This is a follow-up from my previous MR https://github.com/novuhq/novu/pull/3964 to add a new `prop` to the vue notification center component.


### Other information (Screenshots)
I tried to follow the existing documentation for props by using a table to document the new prop.