### PR TITLE
fix: add subscriber info in api-ref (DVRL-2)

### DIFF
--- a/notification-center/client/react/api-reference.mdx
+++ b/notification-center/client/react/api-reference.mdx
@@ -1104,6 +1104,14 @@ customization properties
 | cta.action.buttons        | [IMessageButton[]](#imessagebutton)       | Array of action buttons                                                                              |
 | cta.action.result.payload | `Record<string, unknown>`                 | Payload object that send on updateAction method in useNotifications hook                             |
 | cta.action.result.type    | [ButtonTypeEnum](#buttontypeenum)         | Type of the button                                                                                   |
+| subscriber                | [SubscriberProps](#subscriberprops)       | Payload object that send on updateAction method in useNotifications hook                             |
+
+### SubscriberProps
+| Property     | Type                              | Description                                                      |
+| ------------ | --------------------------------- | ---------------------------------------------------------------- |
+| _id          | string                            | Auto generated identifier for the subscriber entity in database  |
+| firstName    | string                            | First name of the subscriber                                     |
+| subscriberId | string                            | identifier of the subscriber entity in the Novu Web Dashboard    |
 
 ### IMessageButton
 

--- a/notification-center/client/react/api-reference.mdx
+++ b/notification-center/client/react/api-reference.mdx
@@ -1104,14 +1104,14 @@ customization properties
 | cta.action.buttons        | [IMessageButton[]](#imessagebutton)       | Array of action buttons                                                                              |
 | cta.action.result.payload | `Record<string, unknown>`                 | Payload object that send on updateAction method in useNotifications hook                             |
 | cta.action.result.type    | [ButtonTypeEnum](#buttontypeenum)         | Type of the button                                                                                   |
-| subscriber                | [SubscriberProps](#subscriberprops)       | Payload object that send on updateAction method in useNotifications hook                             |
+| subscriber                | [SubscriberProps](#subscriberprops)       | Subscriber object that contains information about the subscriber                                     |
 
 ### SubscriberProps
-| Property     | Type                              | Description                                                      |
-| ------------ | --------------------------------- | ---------------------------------------------------------------- |
-| _id          | string                            | Auto generated identifier for the subscriber entity in database  |
-| firstName    | string                            | First name of the subscriber                                     |
-| subscriberId | string                            | identifier of the subscriber entity in the Novu Web Dashboard    |
+| Property     | Type                              | Description                                                          |
+| ------------ | --------------------------------- | -------------------------------------------------------------------- |
+| _id          | string                            | Auto-generated identifier for the subscriber entity in the database  |
+| firstName    | string                            | First name of the subscriber                                         |
+| subscriberId | string                            | identifier of the subscriber entity in the Novu Web Dashboard        |
 
 ### IMessageButton
 


### PR DESCRIPTION
Add subscriber info in api-ref for headless.

Before: 
![image](https://github.com/novuhq/docs/assets/62152915/cc6bb972-6886-4d47-a00b-8113d42155b6)
After: 
![image](https://github.com/novuhq/docs/assets/62152915/f1553e0a-13a5-42e2-a71d-b25f1b428665)
