### PR TITLE
fix: wrong import of ChatProviderIdEnum

### DIFF
--- a/channels-and-providers/push/fcm.mdx
+++ b/channels-and-providers/push/fcm.mdx
@@ -56,7 +56,7 @@ Before triggering the notification to a subscriber(user) with push as a step in 
 ```javaScript
 import {
   Novu,
-  ChatProviderIdEnum
+  PushProviderIdEnum
 } from '@novu/node';
 
 const novu = new Novu("<NOVU_API_KEY>");


### PR DESCRIPTION
It'll fix the wrong import of `ChatProviderIdEnum` and import `PushProviderIdEnum` instead, as it should.

## Before: 
<img width="828" alt="image" src="https://github.com/novuhq/docs/assets/62152915/be67074b-c26f-4c13-ab3e-1c6b231735f2">

## After: 
<img width="672" alt="image" src="https://github.com/novuhq/docs/assets/62152915/a962006e-226c-4a81-89e6-b1a71b6f1e8a">
