### PR TITLE
fix(docs) - fix typo on topics page

### DIFF
--- a/subscribers/topics.mdx
+++ b/subscribers/topics.mdx
@@ -222,7 +222,7 @@ User X makes a comment, other users (A, B) who've already commented before shoul
     href="/api-reference/topics/topic-creation"
   ></Card>
   <Card
-    title="Add subscriebers to the topic"
+    title="Add subscribers to a topic"
     icon="plug"
     color="#16a34a"
     href="/api-reference/topics/subscribers-addition"
@@ -234,7 +234,7 @@ User X makes a comment, other users (A, B) who've already commented before shoul
     href="/api-reference/topics/check-topic-subscriber"
   ></Card>
   <Card
-    title="Remove subscribers from the topic"
+    title="Remove subscribers from a topic"
     icon="plug"
     color="#16a34a"
     href="/api-reference/topics/subscribers-removal"


### PR DESCRIPTION
Fixes a typo (subscriebers) in the footer of the topics documentation.

Also adjusts headings to match how other areas of the documentation address topic actions:

"...to the topic" -> "...to a topic"