### PR TITLE
feat: Documented idempotent nature of transactionId [DVRL-99]

### DIFF
--- a/_snippets/idempotent-nature-of-transactionId.mdx
+++ b/_snippets/idempotent-nature-of-transactionId.mdx
@@ -1,0 +1,13 @@
+### Idempotent nature of `transactionId`
+
+The `transactionId` within Novu is a unique identifier that is used to ensure the idempotent nature of notification delivery. 
+
+When you trigger an event to send a notification, you have the option to provide a `transactionId`. If you do not provide one, Novu will generate a UUID for you. 
+
+**This identifier is particularly useful for preventing the same notification from being sent multiple times in case the trigger event is inadvertently called more than once.**
+
+By leveraging the `transactionId`, you can make idempotent requests, which means if the same `transactionId` is used in another request, Novu's API will recognize it and will not send the same notification again. 
+
+<Note>
+This upholds the principle of idempotency, ensuring that the effect of the operation is the same, no matter how many times the request is repeated with the same `transactionId`.
+</Note>

--- a/api-reference/events/trigger-event.mdx
+++ b/api-reference/events/trigger-event.mdx
@@ -226,3 +226,8 @@ var trigger = await novu.Event.Trigger(payload);
 ```
 
 </ResponseExample>
+
+<Accordion title="Idempotent nature of transactionId">
+  <Snippet file="idempotent-nature-of-transactionId.mdx" />
+</Accordion>
+

--- a/workflows/notification-workflows.mdx
+++ b/workflows/notification-workflows.mdx
@@ -108,4 +108,8 @@ A `trigger identifier` is a distinctive label utilized to activate a workflow, t
 Hence, while `workflowId` refers to the umbrella structure that holds the entire flow of messages, the `trigger identifier` is the specific event that starts this sequence.
 </Accordion>
 
+<Accordion title="How does Novu prevent duplicate notifications sent to subscribers?">
+  <Snippet file="idempotent-nature-of-transactionId.mdx" />
+</Accordion>
+
 </AccordionGroup>


### PR DESCRIPTION
I've added the information as a reusable snippet.

![Screenshot 2023-12-21 at 15 42 53](https://github.com/novuhq/docs/assets/63902456/02a61a1f-92b2-400a-a5dd-e116ff9efc21)
![Screenshot 2023-12-21 at 15 43 09](https://github.com/novuhq/docs/assets/63902456/70be6f63-16f6-44cc-82f1-ab68f720c94e)
