### PR TITLE
Meeting link replacement

### DIFF
--- a/self-hosting-novu/aws.mdx
+++ b/self-hosting-novu/aws.mdx
@@ -20,5 +20,5 @@ By following these steps, you're helping us enhance the quality and depth of our
 
 Your contributions drive progress. Let's build together!
 
-<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://calendly.com/novuhq/novu-meeting?utm_source=novuDocs&utm_page=deploy-to-AWS). 
+<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_content=deploy-to-AWS). 
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>

--- a/self-hosting-novu/azure.mdx
+++ b/self-hosting-novu/azure.mdx
@@ -22,5 +22,5 @@ By following these steps, you're helping us enhance the quality and depth of our
 Your contributions drive progress. Let's build together!
 
 
-<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://calendly.com/novuhq/novu-meeting?utm_source=novuDocs&utm_page=deploy-to-Azure). 
+<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_content=deploy-to-Azure-docs). 
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>

--- a/self-hosting-novu/deploy-with-docker.mdx
+++ b/self-hosting-novu/deploy-with-docker.mdx
@@ -114,7 +114,7 @@ We are introducing the first stage of caching in our system to improve performan
 Currently, we are caching data in the most heavily loaded areas of the system: the widget requests such as feed and unseen count, as well as common DAL requests during the execution of trigger event flow. These are the most heavily used areas of our system, and we hope that by implementing caching in these areas, we can improve performance in the near future.
 
 
-<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://calendly.com/novuhq/novu-meeting?utm_source=novuDocs&utm_page=deploy-with-Docker).
+<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_content=deploy-with-Docker-docs).
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>
 
 ### Reverse-Proxy / Load Balancers

--- a/self-hosting-novu/gcp.mdx
+++ b/self-hosting-novu/gcp.mdx
@@ -21,5 +21,5 @@ By following these steps, you're helping us enhance the quality and depth of our
 Your contributions drive progress. Let's build together!
 
 
-<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://calendly.com/novuhq/novu-meeting?utm_source=novuDocs&utm_page=deploy-to-GCP). 
+<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_page=deploy-to-GCP). 
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>

--- a/self-hosting-novu/gcp.mdx
+++ b/self-hosting-novu/gcp.mdx
@@ -21,5 +21,5 @@ By following these steps, you're helping us enhance the quality and depth of our
 Your contributions drive progress. Let's build together!
 
 
-<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_page=deploy-to-GCP). 
+<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_content=deploy-to-GCP). 
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>

--- a/self-hosting-novu/introduction.mdx
+++ b/self-hosting-novu/introduction.mdx
@@ -9,7 +9,7 @@ While this offers full control and customization,
 some features which are available only for Novu’s cloud-managed won't be available in a self-hosted environment.
 
 <Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations,
-    please don't hesitate to [contact our team](https://calendly.com/novuhq/novu-meeting?utm_source=novuDocs&utm_page=self-hosting-introduction).
+    please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_page=self-hosting-introduction).
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>
 
 ## Minimum System Requirements

--- a/self-hosting-novu/introduction.mdx
+++ b/self-hosting-novu/introduction.mdx
@@ -9,7 +9,7 @@ While this offers full control and customization,
 some features which are available only for Novu’s cloud-managed won't be available in a self-hosted environment.
 
 <Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations,
-    please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_page=self-hosting-introduction).
+    please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_content=self-hosting-introduction).
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>
 
 ## Minimum System Requirements

--- a/self-hosting-novu/terraform.mdx
+++ b/self-hosting-novu/terraform.mdx
@@ -20,5 +20,5 @@ By following these steps, you're helping us enhance the quality and depth of our
 
 Your contributions drive progress. Let's build together!
 
-<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://calendly.com/novuhq/novu-meeting?utm_source=novuDocs&utm_page=deploy-with-terraform). 
+<Note>If you require guidance on setting up a production-scale configuration, official IaaS recommendations, please don't hesitate to [contact our team](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_content=deploy-with-terraform). 
 They can provide assistance regarding enterprise edition licenses or cloud-prem deployment to meet your specific needs.</Note>

--- a/use-cases/manage-notifications-in-multiple-languages.mdx
+++ b/use-cases/manage-notifications-in-multiple-languages.mdx
@@ -3,4 +3,4 @@ title: "Manage notifications in multiple languages"
 description: "Learn to send notifications in different languages effortlessly"
 ---
 
-This feature is currently under development. However if you urgently need this, [reach out to us for more information](https://calendly.com/novuhq/novu-meeting?utm_source=notifications-in-multiple-languages-docs).
+This feature is currently under development. However if you urgently need this, [reach out to us for more information](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_content=notifications-in-multiple-languages-docs).

--- a/use-cases/send-notifications-at-any-scale.mdx
+++ b/use-cases/send-notifications-at-any-scale.mdx
@@ -3,8 +3,8 @@ title: "Processing and sending notifications at any scale"
 description: "Novu can handle notifications at extremely large scale"
 ---
 
-[Novu's Cloud](https://web.novu.co) is built to process and send notifications at any scale. For folks using the self-hosted Novu version, you can scale it up as your needs grow.
+[Novu's Cloud](https://web.novu.co?utm_campaign=novuDocs&utm_content=send-notifications-at-any-scale-docs) is built to process and send notifications at any scale. For folks using the self-hosted Novu version, you can scale it up as your needs grow.
 
-If you're looking to use Novu on a very large scale & you need to confirm infrastructure & scalability prowess, [please reach out to us for more information](https://calendly.com/novuhq/novu-meeting?utm_source=send-notifications-at-any-scale-docs).
+If you're looking to use Novu on a very large scale & you need to confirm infrastructure & scalability prowess, [please reach out to us for more information](https://notify.novu.co/meetings/novuhq/notifications-45min?utm_campaign=novuDocs&utm_content=send-notifications-at-any-scale-docs).
 
 


### PR DESCRIPTION
Started the (likely somewhat lengthy) process of updating calendly meetings to use Hubspot meetings instead.

I also updated several other outbound links to web.novu.co with new UTM parameters. We'll want to do that for all other Novu.co outbound links, too... eventually.