### PR TITLE
fix: add create subscriber link in python quickstart

### DIFF
--- a/quickstarts/python.mdx
+++ b/quickstarts/python.mdx
@@ -98,7 +98,7 @@ Now, let’s take it a step further to trigger notifications via code.
 
 The recipients of a triggered notification are called subscribers.
 
-Click **Subscribers** on the left sidebar of the Novu dashboard to see all subscribers. By default, the dashboard will display only one subscriber, as you were added automatically during sign-up.
+Click **Subscribers** on the left sidebar of the Novu dashboard to see all subscribers. By default, the dashboard will display only one subscriber, as you were added automatically during sign-up. If default subscriber is not created, checkout [how to create new subscriber.](/subscribers/subscribers#create-a-subscriber)
 
 <Frame>
    <img src="https://res.cloudinary.com/dxc6bnman/image/upload/v1688331839/Screenshot_2023-07-03_at_0.02.53_jmkhi3.png" alt="Subscriber id" />


### PR DESCRIPTION
fixes #442 