### PR TITLE
docs: update fetchNotifications to include limit

### DIFF
--- a/inbox/headless/api-reference.mdx
+++ b/inbox/headless/api-reference.mdx
@@ -204,6 +204,7 @@ headlessService.fetchNotifications({
       message: "Notification message",
       type: "product",
     },
+    limit: 10,
   },
   storeId: "storeId",
 });


### PR DESCRIPTION
## Background

I was a bit confused how to set the limit, but then noticed we spread the query in `httpClient.getFullResponse`, so we can pass limit from here.!

## What has changed?

Adding `limit` to the examples

