### PR TITLE
fix: add delay with in-app and skip

### DIFF
--- a/api-reference/subscribers/get-in-app-notification-feed-for-a-particular-subscriber.mdx
+++ b/api-reference/subscribers/get-in-app-notification-feed-for-a-particular-subscriber.mdx
@@ -7,7 +7,7 @@ import ApikeyWarning from "/snippets/apikey-warning.mdx";
 
 <ApikeyWarning />
 
-<RequestExample>
+<RequestExample />
 
 <ResponseExample>
 ```json Response
@@ -179,6 +179,5 @@ import ApikeyWarning from "/snippets/apikey-warning.mdx";
   "page": "number",
   "pageSize": "number"
 }
-````
-
+```
 </ResponseExample>

--- a/workflow/delay.mdx
+++ b/workflow/delay.mdx
@@ -16,12 +16,15 @@ The delay action awaits a specified amount of time before moving on to trigger t
 Delay steps can be inserted at any stage of your workflow execution, they can happen after or before any action. The workflow execution will be halted for the given amount of time and then resumed to the next step in the flow.
 
 The action can also be skipped using the `skip` parameter conditionally to allow more complex usecases of when to wait and when to send an email immediately.
-
+<Tabs>
+<Tab title="Delay with skip condition">
+Here, we are delaying the execution of the next step by 1 day and skipping the delay step if the `isCriticalMessage` function returns `true`.
 ```typescript
 await step.delay(
   "delay",
   async () => {
     return {
+      type: "regular"
       unit: "days",
       amount: 1,
     };
@@ -31,7 +34,40 @@ await step.delay(
   }
 );
 ```
+</Tab>
+<Tab title="Delay and in-app step with skip">
+Here, we are delaying the execution of the in-app step by 30 minutes and sending the in-app notification only if the subscriber has `goalReminderInAppAllowed` set to `true` for subscriber. If during 30 minutes delay window, subscriber sets `goalReminderInAppAllowed` to `false`, the in-app step will be skipped.
+```typescript
+export const goalReminderInAppAfterDelay = workflow(
+  "goal-reminder-in-app-after-delay",
+  async ({ step, subscriber }) => {
+    await step.delay("delay-step", async () => {
+      return {
+        type: "regular",
+        amount: 30,
+        unit: "minutes",
+      };
+    });
 
+    await step.inApp(
+      "in-app-step",
+      async () => {
+        return {
+          subject: `Don’t Forget Your Fitness Goals Today!`,
+          body: `Hey ${subscriber.firstName}, it's been a while since you logged your
+                last activity. Keep up the momentum and complete your workout to stay on 
+                track with your goals!`,
+        };
+      },
+      {
+        skip: () => (subscriber as any).data?.goalReminderInAppAllowed === false,
+      }
+    );
+  }
+);
+```
+</Tab>
+</Tabs>
 <Info>Changing the step content after triggering the workflow with delay step will not affect the existing pending delayed notification content.</Info>
 
 To read more about the full list of parameters, check out the [full SDK reference](/sdks/framework/typescript/steps/delay).

--- a/workflow/delay.mdx
+++ b/workflow/delay.mdx
@@ -35,7 +35,7 @@ await step.delay(
 );
 ```
 </Tab>
-<Tab title="Delay and in-app step with skip">
+<Tab title="Delay and Inbox step">
 Here, we are delaying the execution of the in-app step by 30 minutes and sending the in-app notification only if the subscriber has `goalReminderInAppAllowed` set to `true` for subscriber. If during 30 minutes delay window, subscriber sets `goalReminderInAppAllowed` to `false`, the in-app step will be skipped.
 ```typescript
 export const goalReminderInAppAfterDelay = workflow(


### PR DESCRIPTION
Added this usecase

> lets say workflow has 2 steps: delay 1 hour and then sms with skip if subscriber.data.isAllowed == false. Workflow was triggered and at that moment isAllowed for particular sub was false, but after 30 mins isAllowed was updated to true. When the workflow reaches sms, which isAllowed value it will use: update(true) or the one that was at the triggering moment(false)?
