### PR TITLE
docs(framework): Add `disableOutputSanitization` for Framework step options

### DIFF
--- a/sdks/framework/typescript/steps/introduction.mdx
+++ b/sdks/framework/typescript/steps/introduction.mdx
@@ -15,7 +15,10 @@ title: "Step Interface"
     });
     ```
     ```typescript Skip
-    await step.email('stepId', resolver, {
+    await step.email('skipped-step',async () => ({
+        subject: 'Hello, world!',
+        body: 'My email message',
+    }), {
         skip: async (controls) => true,
     });
     ```
@@ -36,7 +39,7 @@ title: "Step Interface"
     );
     ```
     ```typescript Provider Overrides
-    await step.email('stepId', resolver, {
+    await step.email('provider-override', resolver, {
       providers: {
         slack: ({ controls, outputs }) => {
           return {
@@ -54,7 +57,7 @@ title: "Step Interface"
     });
     ```
     ```typescript Provider Passthrough
-    await step.email('stepId', resolver, {
+    await step.email('provider-passthrough', resolver, {
       providers: {
         sendgrid: ({ controls, outputs }) => {
           return {

--- a/sdks/framework/typescript/steps/introduction.mdx
+++ b/sdks/framework/typescript/steps/introduction.mdx
@@ -15,7 +15,7 @@ title: "Step Interface"
     });
     ```
     ```typescript Skip
-    await step.email('skipped-step',async () => ({
+    await step.email('skipped-step', async () => ({
         subject: 'Hello, world!',
         body: 'My email message',
     }), {

--- a/sdks/framework/typescript/steps/introduction.mdx
+++ b/sdks/framework/typescript/steps/introduction.mdx
@@ -106,7 +106,7 @@ This is an optional configuration object that defines: [Controls Schema](/framew
 </ResponseField>
 
 <ResponseField name="disableOutputSanitization" type="boolean" default="false">
-  A flag to disable output sanitization for the step. This is useful when you want to return unsescaped content to the provider, or frequently, the `<Inbox/>` component.
+  A flag to disable output sanitization for the step. This is useful when you want to return unsescaped content to the provider or the `<Inbox/>` component.
 </ResponseField>
 
 ### Providers Overrides Object

--- a/sdks/framework/typescript/steps/introduction.mdx
+++ b/sdks/framework/typescript/steps/introduction.mdx
@@ -20,9 +20,20 @@ title: "Step Interface"
     });
     ```
     ```typescript Disable Output Sanitization
-    await step.email('stepId', resolver, {
+    await step.inApp(
+      'without-sanitization',
+      async () => ({
+        body: 'My in-app message',
+        data: {
+          link: '/pipeline/123?active=true&env=prod',
+        },
+      }),
+      {
+        // Prevent the `&` character in `data.link` from
+        // being converted to `&amp;`
         disableOutputSanitization: true,
-    });
+      }
+    );
     ```
     ```typescript Provider Overrides
     await step.email('stepId', resolver, {

--- a/sdks/framework/typescript/steps/introduction.mdx
+++ b/sdks/framework/typescript/steps/introduction.mdx
@@ -19,6 +19,11 @@ title: "Step Interface"
         skip: async (controls) => true,
     });
     ```
+    ```typescript Disable Output Sanitization
+    await step.email('stepId', resolver, {
+        disableOutputSanitization: true,
+    });
+    ```
     ```typescript Provider Overrides
     await step.email('stepId', resolver, {
       providers: {
@@ -98,6 +103,10 @@ This is an optional configuration object that defines: [Controls Schema](/framew
 
 <ResponseField name="providers" type="ProvidersOverride">
   This object used to access and override the underlying deliver providers SDKs. This is useful when you want to customize the content of the notification with properties that are unique to the provider.
+</ResponseField>
+
+<ResponseField name="disableOutputSanitization" type="boolean" default="false">
+  A flag to disable output sanitization for the step. This is useful when you want to return unsescaped content to the provider, or frequently, the `<Inbox/>` component.
 </ResponseField>
 
 ### Providers Overrides Object


### PR DESCRIPTION
**What?**
* Add documentation for `disableOutputSanitization` in Framework step options

**Screenshots**
_Example & documentation_
<img width="1727" alt="image" src="https://github.com/user-attachments/assets/25af1576-aebc-461c-90ad-a2fef7250092">

**Related PR:**
https://github.com/novuhq/novu/pull/6521