### PR TITLE
chore: inbox docs on how to filter preferences

### DIFF
--- a/inbox/react/components/inbox.mdx
+++ b/inbox/react/components/inbox.mdx
@@ -8,16 +8,16 @@ By default, the `<Inbox />` renders a bell button, that opens a popover on click
 import { Inbox } from '@novu/react';
 
 function Novu() {
-    return (
-        <Inbox
-        applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
-        subscriberId="YOUR_SUBSCRIBER_ID"
-        />
-    );
+  return (
+    <Inbox
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriberId="YOUR_SUBSCRIBER_ID"
+    />
+  );
 }
 ```
 
-## Navigation 
+## Navigation
 
 The Inbox component uses the `routerPush` prop to make your notifications navigatable. We will automatically pass the `redirect.url` from your workflow definitions to the `routerPush` prop.
 
@@ -106,9 +106,8 @@ To make the navigation work, you will need to specify the `routerPush` behaviour
       );
     }
     ```
+
 </CodeGroup>
-
-
 
 ### Handle notification click
 
@@ -156,7 +155,6 @@ function Novu() {
   );
 }
 ```
-
 
 ## Controlled Popover state
 
@@ -226,3 +224,22 @@ function Novu() {
 }
 ```
 
+## Filter visible preferences
+
+You can customize the visible preferences by passing the `preferencesFilter` prop to the Inbox component, allowing you to display only relevant preferences to your users.
+The filtering works by matching the workflow [tags](/workflow/introduction#tags) field with the specified filter `tags` value, showing workflows that contain at least one associated tag.
+Additionally, you can combine tags from different workflows to create a tailored preferences view.
+
+```tsx
+import { Inbox, Preferences } from '@novu/react';
+
+function Novu() {
+  return (
+    <Inbox
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriberId="YOUR_SUBSCRIBER_ID"
+      preferencesFilter={{ tags: ['mention', 'newsletter', 'security'] }}
+    />
+  );
+}
+```

--- a/inbox/react/components/inbox.mdx
+++ b/inbox/react/components/inbox.mdx
@@ -238,7 +238,7 @@ function Novu() {
     <Inbox
       applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
       subscriberId="YOUR_SUBSCRIBER_ID"
-      preferencesFilter={{ tags: ['mention', 'newsletter', 'security'] }}
+      preferencesFilter={{ tags: ['general', 'admin', 'security'] }}
     />
   );
 }

--- a/inbox/react/multiple-tabs.mdx
+++ b/inbox/react/multiple-tabs.mdx
@@ -9,9 +9,9 @@ Novu enables the creation of a multi-tab experience for the Inbox, allowing you 
 
 Define the `tabs` prop to display multiple tabs in the Inbox component.
 
-Each tab object should include a `label` and `value` properties. The `label` property represents the text displayed on the specific tab. The `value` property is an array of strings that serves as the "filter criteria" for the notifications displayed in the list.
+Each tab object should include a `label` and `filter` properties. The `label` property represents the text displayed on the specific tab. The `filter` property is an object that serves as the "filter criteria" for the notifications displayed in the list. The filter should include the `tags` which is an array of strings.
 
-The notifications are filtered and matched by comparing the [workflow](/workflow/introduction#tags) `tags` field with the tab `value` field. Each notification is a part of a specific [workflow](/concepts/workflows). You can combine tags from different workflows to create a customized tab experience.
+The notifications are filtered and matched by comparing the [workflow](/workflow/introduction#tags) `tags` field with the tab `filter.tags` array. Each notification is a part of a specific [workflow](/concepts/workflows). You can combine tags from different workflows to create a customized tab experience.
 
 The example below demonstrates how to define multiple tabs in the Inbox component.
 
@@ -21,15 +21,15 @@ import { Inbox } from '@novu/react';
 const tabs = [
   {
     label: 'All Notifications',
-    value: [],
+    filter: { tags: [] },
   },
   {
     label: 'Newsletter',
-    value: ['newsletter'],
+    filter: { tags: ['newsletter'] },
   },
   {
     label: 'React',
-    value: ['react'],
+    filter: { tags: ['react'] },
   },
 ];
 
@@ -48,4 +48,7 @@ function InboxNovu() {
   <img src="/images/inbox/component.png" />
 </Frame>
 
-<Info>Here tab value is taken from workflow tags. Tags can be configured in options field of [workflow](/sdks/framework/typescript/workflow).</Info>
+<Info>
+  Here tab `filter.tags` are taken from workflow tags. Tags can be configured in
+  options field of [workflow](/sdks/framework/typescript/workflow).
+</Info>


### PR DESCRIPTION
Inbox docs update:
- how to filter visible preferences
- updated the Tabs page with latest changes to `tabs` property 

![Screenshot 2024-09-19 at 11 13 10](https://github.com/user-attachments/assets/7847de36-84d9-4158-9449-e012142ba28c)

![Screenshot 2024-09-19 at 11 12 44](https://github.com/user-attachments/assets/175f03e0-46c3-46c5-88d8-6623c08440ab)
