### PR TITLE
chore: update figma link

### DIFF
--- a/inbox/introduction.mdx
+++ b/inbox/introduction.mdx
@@ -38,4 +38,4 @@ Novu provides a pre-built, ready-to-use, and customizable Inbox UI component. It
 
 ## Design files
 
-To aide your design process, we provide a [Figma file](https://www.figma.com/design/0FIyK1FshxvMeYtJL5xsAa/External-Inbox-Design-File?node-id=2-4268&t=AEcemYHcITm8XDVR-0) that contains all of the design assets. Make a copy of the file into your own account to get started with customizing your graphical inbox elements.
+To aide your design process, we provide a free [Figma file](https://www.figma.com/community/file/1425407348374863860) that contains all of the design assets. Make a copy of the file into your own account to get started with customizing your graphical Inbox elements.


### PR DESCRIPTION
Updated a single link in `/inbox/introduction`

The Figma link now points to the community page rather than the Figma file directly. 