### PR TITLE
docs(subscribers): Clarify subscriber delivery data and metadata handling instructions

### DIFF
--- a/concepts/subscribers.mdx
+++ b/concepts/subscribers.mdx
@@ -117,25 +117,60 @@ A non-existing subscriber can be added by sending subscriber data in `to` fiel
         $novu->triggerEvent([
         'name' => '<WORKFLOW_TRIGGER_IDENTIFIER>',
             'to' => [
-            'subscriberId' => '111',
-            'email' => 'john.doe@domain.com',
-            'firstName' => 'John',
-            'lastName'  => 'Doe',
-            'phone' => '+13603963366'
+                'subscriberId' => '111',
+                'email' => 'john.doe@domain.com',
+                'firstName' => 'John',
+                'lastName'  => 'Doe',
+                'phone' => '+13603963366'
             ]
             'payload' => [
-            'customVariable' => 'variableValue',
-            'organization' => [
-            'logo' => 'https://organization.com/logo.png',
-            ]
+                'customVariable' => 'variableValue',
+                'organization' => [
+                    'logo' => 'https://organization.com/logo.png',
+                ]
             ],
-            ]);
-            ```
+        ]);
+        ```
     </Tab>
 
 </Tabs>
 
-You can also pass only the `subscriberId` during a request, and hydrate the data directly from your database or other sources during the trigger execution. This is useful when you don't want to store all the subscriber data in Novu.
+When triggering the workflow, you must specify all required `to` fields per the channels in the workflow. For example, if an email step is included in the workflow, then the `to.email` field must be specified. Similarly if an SMS step is included, the `to.phone` field must be specified.
+
+If you are defining workflows with code, you can use the `subscriberId` to hydrate subscriber data directly from your database or other sources during workflow execution. This is useful when you don't want to store all the subscriber data in Novu.
+
+For example, you may have a welcome onboarding email that you trigger immediately after a user signs up, with the email only sent 1 hour after signup:
+
+```typescript
+import { workflow } from '@novu/framework';
+import { userDb } from '../db/userDb';
+
+export const welcomeEmail = workflow('welcome-email', async ({ step, subscriber }) => {
+  await step.delay('delay', () => ({ amount: 1, unit: 'hours' }));
+
+  await step.email('send-email', async (controls) => {
+    // Fetch user data from your database in real-time to
+    // ensure up-to-date information
+    const user = await userDb.findById(subscriber.subscriberId);
+
+    return {
+      subject: `Welcome, ${user.firstName}`,
+      body: 'Welcome to our platform!',
+    };
+  });
+});
+```
+
+Then, when you trigger the workflow, you can pass the `subscriberId` and the workflow will fetch the user data from your database in real-time:
+
+```typescript
+await welcomeEmail.trigger({
+  to: {
+    subscriberId: '123',
+    email: 'john.doe@domain.com',
+  },
+});
+```
 
 ### Migration (Optional)
 


### PR DESCRIPTION
### What?
* Clarify subscriber data handling instructions

### Why?
The previous documentation was ambiguous with respect to fetching subscriber delivery data in realtime.

### Screenshots
_Preview Deployment_
https://novu-clarify-subscriber-data-resolution.mintlify.app/concepts/subscribers#just-in-time

_New Content_
<img width="600" alt="image" src="https://github.com/user-attachments/assets/22e44314-3920-468b-8d41-94292f908f2b">
