### PR TITLE
fix: add info for @novu/react compatibility with @novu/framework

### DIFF
--- a/getting-started/introduction.mdx
+++ b/getting-started/introduction.mdx
@@ -4,6 +4,14 @@ description: "Novu is a full-stack (UI Components, API, and Framework) open sour
 ---
 
 import { FrameworkTerminal } from "/snippets/framework-terminal.mdx";
+import { SvelteIcon } from "/snippets/icons/svelte.mdx";
+import { NestjsIcon } from "/snippets/icons/nestjs.mdx";
+import { ExpressjsIcon } from "/snippets/icons/expressjs.mdx";
+import { LambdaIcon } from "/snippets/icons/lambda.mdx";
+import { NuxtIcon } from "/snippets/icons/nuxt.mdx";
+import { NextjsIcon } from "/snippets/icons/nextjs.mdx";
+import { RemixIcon } from "/snippets/icons/remix.mdx";
+import { H3Icon } from "/snippets/icons/h3.mdx";
 
  Novu is a developer-first product built for engineers looking to deliver a notifications platform for products. Novu simplifies the complexities of notification management for developers who can then empower the product and marketing teams that need to edit and maintain notification content and copy. Novu supports a variety of common notification channels out-of-the-box, including **Email**, **SMS**, **Push**, **Inbox**, and **Chat**.
 

--- a/inbox/react/migration-guide.mdx
+++ b/inbox/react/migration-guide.mdx
@@ -4,6 +4,9 @@ sidebarTitle: "Migration Guide"
 description: "This guide outlines the key differences between the `@novu/notification-center` package and the new `@novu/react` package. Follow the steps below to migrate your application to the latest version."
 ---
 
+<Info> [@novu/react](/inbox/react/get-started) Inbox react component and [@novu/js](/inbox/headless/get-started) headless package is compatible with [@novu/framework](/workflow/introduction) based workflows only. With old UI based workflows, our old [@novu/notification-center](https://v0.x-docs.novu.co/notification-center/client/react/get-started) component should be used.</Info>
+
+
 The `@novu/react` package introduces a more flexible and customizable way to display notifications in your application. This guide outlines the key differences between the `@novu/notification-center` package and the new `@novu/react` package. Follow the steps below to migrate your application to the latest Inbox version.
 
 ## Why you should upgrade to @novu/react


### PR DESCRIPTION
1. Add missing icons on introduction page
2. Add information for @novu/react with @novu/framework compatibility