### PR TITLE
docs(fix): Remove Remix references from nuxt.mdx

### DIFF
--- a/quickstart/nuxt.mdx
+++ b/quickstart/nuxt.mdx
@@ -41,7 +41,7 @@ In this guide, we will add a Novu [Bridge Endpoint](/concepts/endpoint) to a Nux
         cd my-novu-app && npm run dev
         ```
 
-        If your Nuxt application is running on other than `3000` port, restart the `npx novu dev` command with the port:
+       Nuxt application default port is 3000. For that to work, restart Novu Studio and point it to the right port:
 
         ```bash
         npx novu@latest dev --port <YOUR_NUXT_PORT>

--- a/quickstart/nuxt.mdx
+++ b/quickstart/nuxt.mdx
@@ -35,19 +35,19 @@ In this guide, we will add a Novu [Bridge Endpoint](/concepts/endpoint) to a Nux
     </Step>
 
     <Step title="Start your application">
-        To start your Remix server with the Novu Endpoint configured, run the following command:
+        Start your Nuxt application with the Novu Endpoint configured.
 
         ```bash
         cd my-novu-app && npm run dev
         ```
 
-        If your Remix application is running on other than `4000` port, restart the `npx novu dev` command with the port:
+        If your Nuxt application is running on other than `3000` port, restart the `npx novu dev` command with the port:
 
         ```bash
-        npx novu@latest dev --port <YOUR_REMIX_PORT>
+        npx novu@latest dev --port <YOUR_NUXT_PORT>
         ```
     </Step>
-    <TestStep framework="Remix" />
+    <TestStep framework="Nuxt" />
     <DeployApp />
 
 </Steps>


### PR DESCRIPTION
Remove Remix references and replace them with Nuxt, adjusting the port from 4000 to 3000