### PR TITLE
fix: wrong variable name in code example

### DIFF
--- a/framework/quickstart/nuxt.mdx
+++ b/framework/quickstart/nuxt.mdx
@@ -22,7 +22,7 @@ In this guide, we will add a Novu [Bridge Endpoint](/concepts/endpoint) to a Nux
             import { serve } from '@novu/framework/nuxt';
             import { testWorkflow } from "../novu/workflows";
 
-            export default defineEventHandler(serve({ workflows: [myWorkflow] }));
+            export default defineEventHandler(serve({ workflows: [testWorkflow] }));
             ```
         </CodeGroup>
     </Step>


### PR DESCRIPTION
Wrong referenced variable when instantiating library in code example.