### PR TITLE
fix: add limitation info for using provider template in email channel

### DIFF
--- a/content/docs/platform/integrations/email/(providers)/mailersend.mdx
+++ b/content/docs/platform/integrations/email/(providers)/mailersend.mdx
@@ -25,62 +25,67 @@ To use the MailerSend provider in the email channel, you will need to create a M
 
 Novu has its own email editor for writing email template. If you want to use pre made template from MailerSend, you can use `customData` filed of email overrides to send template details. Make sure your `Api Key` has enough permission to read and process the template.
 
+<Callout type="info">
+  sending `customData` field in overrides to send mailersend template will work only in following cases:
+  - if workflow is triggered to only one subscriber 
+  - if workflow is triggered to multiple subscribers or topic but mailersend template does not have any dynamic variables related to subscriber attributes like `firstName`, `lastName`, `email`, etc as same overrides will be applied to all subscribers or topic
+</Callout>
+
 <Tabs items={['Node.js', 'cURL']}>
 <Tab value="Node.js">
 ```jsx
 import {
-  Novu
+    Novu
 } from '@novu/node';
 
 const novu = new Novu('<NOVU_SECRET_KEY>');
 
 await novu.subscribers.trigger("workflowIdentifier", {
-to: "subscriberId",
-payload: {},
-overrides: {
-email: {
-customData: {
-// mailersend template templateId
-templateId: 'mailersend-template-id',
-// mailersend template variables
-personalization: [{
-email: 'recipient@email.com',
-data: {
-items: {
-price: '',
-product: '',
-quantity: '',
-},
-order: {
-date: '',
-order_number: '',
-billing_address: '',
-customer_message: '',
-},
-store: {
-name: '',
-},
-invoice: {
-total: '',
-subtotal: '',
-pay_method: '',
-},
-customer: {
-name: '',
-email: '',
-phone: '',
-},
-},
-}, ],
-},
-}
-},
-// actorId is subscriberId of actor
-actor: "actorId"
-tenant: "tenantIdentifier"
+    to: "subscriberId",
+    payload: {},
+    overrides: {
+        email: {
+            customData: {
+                // mailersend template templateId
+                templateId: 'mailersend-template-id',
+                // mailersend template variables
+                personalization: [{
+                    email: 'recipient@email.com',
+                    data: {
+                        items: {
+                            price: '',
+                            product: '',
+                            quantity: '',
+                        },
+                        order: {
+                            date: '',
+                            order_number: '',
+                            billing_address: '',
+                            customer_message: '',
+                        },
+                        store: {
+                            name: '',
+                        },
+                        invoice: {
+                            total: '',
+                            subtotal: '',
+                            pay_method: '',
+                        },
+                        customer: {
+                            name: '',
+                            email: '',
+                            phone: '',
+                        },
+                    },
+                }, ],
+            },
+        }
+    },
+    // actorId is subscriberId of actor
+    actor: "actorId"
+    tenant: "tenantIdentifier"
 });
-
-````
+```
 </Tab>
 <Tab value="cURL">
 ```bash

--- a/content/docs/platform/integrations/email/(providers)/mailersend.mdx
+++ b/content/docs/platform/integrations/email/(providers)/mailersend.mdx
@@ -81,9 +81,6 @@ await novu.subscribers.trigger("workflowIdentifier", {
             },
         }
     },
-    // actorId is subscriberId of actor
-    actor: "actorId"
-    tenant: "tenantIdentifier"
 });
 ```
 </Tab>

--- a/content/docs/platform/integrations/email/(providers)/sendgrid.mdx
+++ b/content/docs/platform/integrations/email/(providers)/sendgrid.mdx
@@ -102,9 +102,6 @@ await novu.subscribers.trigger("workflowIdentifier", {
             },
         },
     },
-    // actorId is subscriberId of actor
-    actor: "actorId",
-    tenant: "tenantIdentifier",
 });
 ```
 </Tab>

--- a/content/docs/platform/integrations/email/(providers)/sendgrid.mdx
+++ b/content/docs/platform/integrations/email/(providers)/sendgrid.mdx
@@ -54,55 +54,59 @@ SendGrid allows you to authenticate your sender identity using one of the follow
 
 Novu has its own email editor for writing email template. To send pre-made template in SendGrid, `customData` filed of email overrides can be used to send template details. Make sure sendgrid `Api Key` has enough permission to read and process the template. This `customData` field can be used to send custom args and extra data in the form of key-value pairs.
 
+<Callout type="info">
+  sending `customData` field in overrides to send sendgrid template will work only in following cases:
+  - if workflow is triggered to only one subscriber 
+  - if workflow is triggered to multiple subscribers or topic but sendgrid template does not have any dynamic variables related to subscriber attributes like `firstName`, `lastName`, `email`, etc as same overrides will be applied to all subscribers or topic
+</Callout>
+
 <Tabs items={['Node.js', 'cURL', 'Novu Framework']}>
 <Tab value="Node.js">
 ```typescript
-import { Novu } from "@novu/node";
+import {
+    Novu
+} from "@novu/node";
 
 const novu = new Novu("<NOVU_SECRET_KEY>");
 
 await novu.subscribers.trigger("workflowIdentifier", {
-to: "subscriberId",
-payload: {},
-overrides: {
-email: {
-customData: {
-// sendgrid template templateId
-templateId: "sendgrid-template-id",
-// sendgrid template variables
-dynamicTemplateData: {
-total: "$ 239.85",
-items: [
-{
-text: "New Line Sneakers",
-image:
-"https://marketing-image-production.s3.amazonaws.com/uploads/8dda1131320a6d978b515cc04ed479df259a458d5d45d58b6b381cae0bf9588113e80ef912f69e8c4cc1ef1a0297e8eefdb7b270064cc046b79a44e21b811802.png",
-price: "$ 79.95",
-},
-{
-text: "Old Line Sneakers rlfjrjrh4hr4rh4",
-image:
-"https://marketing-image-production.s3.amazonaws.com/uploads/3629f54390ead663d4eb7c53702e492de63299d7c5f7239efdc693b09b9b28c82c924225dcd8dcb65732d5ca7b7b753c5f17e056405bbd4596e4e63a96ae5018.png",
-price: "$ 79.95",
-},
-],
-receipt: true,
-name: "Sample Name",
-address01: "1234 Fake St.",
-address02: "Apt. 123",
-city: "Place",
-state: "CO",
-zip: "80202",
-},
-},
-},
-},
-// actorId is subscriberId of actor
-actor: "actorId",
-tenant: "tenantIdentifier",
+    to: "subscriberId",
+    payload: {},
+    overrides: {
+        email: {
+            customData: {
+                // sendgrid template templateId
+                templateId: "sendgrid-template-id",
+                // sendgrid template variables
+                dynamicTemplateData: {
+                    total: "$ 239.85",
+                    items: [{
+                            text: "New Line Sneakers",
+                            image: "https://marketing-image-production.s3.amazonaws.com/uploads/8dda1131320a6d978b515cc04ed479df259a458d5d45d58b6b381cae0bf9588113e80ef912f69e8c4cc1ef1a0297e8eefdb7b270064cc046b79a44e21b811802.png",
+                            price: "$ 79.95",
+                        },
+                        {
+                            text: "Old Line Sneakers rlfjrjrh4hr4rh4",
+                            image: "https://marketing-image-production.s3.amazonaws.com/uploads/3629f54390ead663d4eb7c53702e492de63299d7c5f7239efdc693b09b9b28c82c924225dcd8dcb65732d5ca7b7b753c5f17e056405bbd4596e4e63a96ae5018.png",
+                            price: "$ 79.95",
+                        },
+                    ],
+                    receipt: true,
+                    name: "Sample Name",
+                    address01: "1234 Fake St.",
+                    address02: "Apt. 123",
+                    city: "Place",
+                    state: "CO",
+                    zip: "80202",
+                },
+            },
+        },
+    },
+    // actorId is subscriberId of actor
+    actor: "actorId",
+    tenant: "tenantIdentifier",
 });
-
-````
+```
 </Tab>
 <Tab value="cURL">
 ```bash


### PR DESCRIPTION
- add info with explanation in which cases provider templates can be used using overrides