### PR TITLE
feat: integrate ThemeProvider for improved theming support

### DIFF
--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { ThemeProvider } from 'next-themes';
 import { RootProvider } from 'fumadocs-ui/provider';
 import dynamic from 'next/dynamic';
 import type { ReactNode } from 'react';
@@ -8,14 +9,13 @@ const SearchDialog = dynamic(() => import('@/components/search')); // lazy load
 export function Provider({ children }: { children: ReactNode }) {
   return (
     <RootProvider
-      theme={{
-        defaultTheme: 'light',
-      }}
       search={{
         SearchDialog: process.env.NEXT_PUBLIC_ORAMA_API_KEY ? SearchDialog : () => <></>,
       }}
     >
-      {children}
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+        {children}
+      </ThemeProvider>
     </RootProvider>
   );
 }


### PR DESCRIPTION
# Description

This PR adds theming capabilities by integrating `ThemeProvider` from `next-themes`:

- Imported `ThemeProvider` in `src/app/provider.tsx`.  
- Wrapped the application children in `<ThemeProvider attribute="class" defaultTheme="system" enableSystem>`.  
- Removed hardcoded `defaultTheme` config in `RootProvider` to delegate theme control to `next-themes`.  

# Type of Change

- [x] feat: New feature  
- [x] fix: Bug fix

# How Has This Been Tested?

- [x] Manual tests:  
  - Verified light/dark mode toggles on system theme change and user override.  
  - Confirmed CSS class switching on `<html>` element.

# Checklist

- [x] My code follows the project's coding style
- [x] My changes generate no new warnings  