### PR TITLE
fix:Update `<Inbox />` Headless Tab Docs for `@novu/js` SDK Initialization

### DIFF
--- a/content/docs/platform/inbox/react/headless.mdx
+++ b/content/docs/platform/inbox/react/headless.mdx
@@ -11,7 +11,12 @@ The headless version of Novu’s notification library package provides users wit
     ### Install the SDK
 
 ```package-install
-npm i @novu/js
+import { Novu } from "@novu/js";
+
+export const novu = new Novu({
+  applicationIdentifier: '',
+  subscriberId: '',
+});
 ```
 
 </Step>

--- a/content/docs/platform/inbox/react/headless.mdx
+++ b/content/docs/platform/inbox/react/headless.mdx
@@ -11,12 +11,7 @@ The headless version of Novu’s notification library package provides users wit
     ### Install the SDK
 
 ```package-install
-import { Novu } from "@novu/js";
-
-export const novu = new Novu({
-  applicationIdentifier: '',
-  subscriberId: '',
-});
+npm i @novu/js
 ```
 
 </Step>
@@ -27,8 +22,9 @@ export const novu = new Novu({
 ```typescript
 import { Novu } from "@novu/js";
 
-const novu = new Novu({
-  apiKey: 'YOUR_API_KEY',
+export const novu = new Novu({
+  applicationIdentifier: 'YOUR_APPLICATION_IDENTIFIER',
+  subscriberId: 'YOUR_SUBSCRIBER_ID',
 });
 ```
 


### PR DESCRIPTION
## 🛠 Fix: Updated Novu SDK Initialization Example

The previous documentation used a deprecated method for initializing the Novu SDK via `@novu/js`. This update corrects the code snippet and clarifies the recommended usage for developers using the Headless `<Inbox />` component.

### 🚨 Problem

The documentation previously showed:

```ts title="Deprecated"
import { Novu } from "@novu/js";

const novu = new Novu({
  apiKey: 'YOUR_API_KEY',
});

However, this is no longer valid in the latest versions of the SDK, as the apiKey parameter is not recognized or used.

Solution:

import { Novu } from "@novu/js";

```ts title="Initialize Novu SDK (Correct Usage)"
export const novu = new Novu({
  applicationIdentifier: 'YOUR_APPLICATION_IDENTIFIER',
  subscriberId: 'YOUR_SUBSCRIBER_ID',
});