### PR TITLE
Add new roles and permissions page

### DIFF
--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -4,9 +4,9 @@ description: 'Learn how roles and permissions are managed within Novu organizati
 icon: user-lock
 
 ---
-Novu uses a role-based access control (RBAC) model at the organization level. Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard.
+Novu uses a role-based access control (RBAC) model at the [organization level](/platform/how-novu-works#organization-and-environments). Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard. Every user can belong to more than one organization, each with separate configurations and permissions.
 
-You assign a role to a team member when you invite them to your Novu organization. You can later update their role from the [Team section](https://dashboard.novu.co/settings/team) in your organization settings.
+When you invite a team member to your organization, you can assign them a role that determines the actions they can perform within that organization. You can later update their role from the [Team section](https://dashboard.novu.co/settings/team) in your organization settings.
 
 <Callout type="info">
   This feature is available to users on the Team and Enterprise pricing plans, and it is supported on both the new dashboard and the legacy dashboard.

--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -1,0 +1,45 @@
+---
+title: 'Roles and persmissions'
+description: 'Learn about roles and permissions in Novu'
+---
+Novu uses a role-based access control (RBAC) model at the organization level. Each member in your Novu account is assigned a role that determines the actions they can perform within the Novu dashboard.
+
+You assign a role to a team member when you invite them to your Novu organization. You can later update their role from the Team section in your organization settings.
+
+Below is an overview of the four roles available in Novu:
+- **Owner**. For your primary account administrator. This role has full access across the platform, including organization-level settings, billing, API keys, environment management, and user administration. Each Novu organization must have at least one owner.
+
+- **Admin**. For users who manage configuration and operational aspects of Novu. Admins can manage workflows, integrations, subscribers, environments, and message logs. They do not have access to billing.
+
+- **Author**. For users who design and update notification workflows. Authors can create and modify workflows, preview steps, manage topics, and trigger events. They do not have access to organization-level settings, billing, or member management.
+
+- **Viewer**. For read-only users. Viewers can view workflows, environments, logs, and messages, but cannot create, update, or delete resources.
+
+## Roles and permissions table
+
+Below is a detailed table showing which permissions are associated with each role.
+
+Legend:
+- 📖 - Read access
+- ✅ - Write (full access: read, write, delete)
+- ❌ - No access
+
+| Permission                      | **Viewer** | **Author** | **Admin** | **Owner** |
+| ------------------------------ | ---------- | ---------- | --------- | --------- |
+| Create and manage environments | ❌         | ❌         | ✅         | ✅         |
+| Create and manage messages     | 📖         | ✅         | ✅         | ✅         |
+| Create and manage topics       | 📖         | ✅         | ✅         | ✅         |
+| Create and manage webhooks     | 📖         | 📖         | ✅         | ✅         |
+| Create and manage workflows    | 📖         | ✅         | ✅         | ✅         |
+| Manage API keys                | 📖         | ❌         | ✅         | ✅         |
+| Manage billing                 | ❌         | ❌         | ❌         | ✅         |
+| Manage bridges                 | ❌         | ❌         | ✅         | ✅         |
+| Manage custom domains          | 📖         | 📖         | ✅         | ✅         |
+| Manage integrations            | 📖         | 📖         | ✅         | ✅         |
+| Manage organization metadata   | ❌         | ❌         | ❌         | ✅         |
+| Manage organization profile    | ❌         | ❌         | ❌         | ✅         |
+| Manage partner integrations    | 📖         | 📖         | ✅         | ✅         |
+| Manage subscribers             | 📖         | ✅         | ✅         | ✅         |
+| Trigger events                 | ❌         | ✅         | ✅         | ✅         |
+| View and manage team members   | 📖         | 📖         | 📖         | ✅         |
+| View notifications             | 📖         | 📖         | 📖         | 📖         |

--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Roles and persmissions'
 description: 'Learn how roles and permissions are managed within Novu organizations'
-icon: ShieldCheck
+icon: user-lock
 
 ---
 Novu uses a role-based access control (RBAC) model at the organization level. Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard.

--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -1,10 +1,16 @@
 ---
 title: 'Roles and persmissions'
-description: 'Learn about roles and permissions in Novu'
+description: 'Learn how roles and permissions are managed within Novu organizations'
+icon: ShieldCheck
+
 ---
 Novu uses a role-based access control (RBAC) model at the organization level. Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard.
 
 You assign a role to a team member when you invite them to your Novu organization. You can later update their role from the [Team section](https://dashboard.novu.co/settings/team) in your organization settings.
+
+<Callout type="info">
+  This feature is available to users on the Team and Enterprise pricing plans, and is supported on both the new dashboard and the legacy dashboard.
+</Callout>
 
 Below is an overview of the four roles available in Novu:
 - **Owner**. For your primary account administrator. This role has full access across the platform, including organization-level settings, billing, API keys, environment management, and user administration. Each Novu organization must have at least one owner.

--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Roles and persmissions'
+title: 'Roles and permissions'
 description: 'Learn how roles and permissions are managed within Novu organizations'
 icon: user-lock
 
@@ -27,25 +27,25 @@ Below is a detailed table showing which permissions are associated with each rol
 
 Legend:
 - 📖 - Read access
-- ✅ - Write (full access: read, write, delete)
+- ✏️ - Write (full access: read, write, delete)
 - ❌ - No access
 
 | Permission                      | **Viewer** | **Author** | **Admin** | **Owner** |
 | ------------------------------ | ---------- | ---------- | --------- | --------- |
-| Create and manage environments | ❌         | ❌         | ✅         | ✅         |
-| Create and manage messages     | 📖         | ✅         | ✅         | ✅         |
-| Create and manage topics       | 📖         | ✅         | ✅         | ✅         |
-| Create and manage webhooks     | 📖         | 📖         | ✅         | ✅         |
-| Create and manage workflows    | 📖         | ✅         | ✅         | ✅         |
-| Manage API keys                | 📖         | ❌         | ✅         | ✅         |
-| Manage billing                 | ❌         | ❌         | ❌         | ✅         |
-| Manage bridges                 | ❌         | ❌         | ✅         | ✅         |
-| Manage custom domains          | 📖         | 📖         | ✅         | ✅         |
-| Manage integrations            | 📖         | 📖         | ✅         | ✅         |
-| Manage organization metadata   | ❌         | ❌         | ❌         | ✅         |
-| Manage organization profile    | ❌         | ❌         | ❌         | ✅         |
-| Manage partner integrations    | 📖         | 📖         | ✅         | ✅         |
-| Manage subscribers             | 📖         | ✅         | ✅         | ✅         |
-| Trigger events                 | ❌         | ✅         | ✅         | ✅         |
-| View and manage team members   | 📖         | 📖         | 📖         | ✅         |
+| Create and manage environments | ❌         | ❌         | ✏️         | ✏️         |
+| Create and manage messages     | 📖         | ✏️         | ✏️         | ✏️         |
+| Create and manage topics       | 📖         | ✏️         | ✏️         | ✏️         |
+| Create and manage webhooks     | 📖         | 📖         | ✏️         | ✏️         |
+| Create and manage workflows    | 📖         | ✏️         | ✏️         | ✏️         |
+| Manage API keys                | 📖         | ❌         | ✏️         | ✏️         |
+| Manage billing                 | ❌         | ❌         | ❌         | ✏️         |
+| Manage bridges                 | ❌         | ❌         | ✏️         | ✏️         |
+| Manage custom domains          | 📖         | 📖         | ✏️         | ✏️         |
+| Manage integrations            | 📖         | 📖         | ✏️         | ✏️         |
+| Manage organization metadata   | ❌         | ❌         | ❌         | ✏️         |
+| Manage organization profile    | ❌         | ❌         | ❌         | ✏️         |
+| Manage partner integrations    | 📖         | 📖         | ✏️         | ✏️         |
+| Manage subscribers             | 📖         | ✏️         | ✏️         | ✏️         |
+| Trigger events                 | ❌         | ✏️         | ✏️         | ✏️         |
+| View and manage team members   | 📖         | 📖         | 📖         | ✏️         |
 | View notifications             | 📖         | 📖         | 📖         | 📖         |

--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -9,7 +9,7 @@ Novu uses a role-based access control (RBAC) model at the organization level. Ea
 You assign a role to a team member when you invite them to your Novu organization. You can later update their role from the [Team section](https://dashboard.novu.co/settings/team) in your organization settings.
 
 <Callout type="info">
-  This feature is available to users on the Team and Enterprise pricing plans, and is supported on both the new dashboard and the legacy dashboard.
+  This feature is available to users on the Team and Enterprise pricing plans, and it is supported on both the new dashboard and the legacy dashboard.
 </Callout>
 
 Below is an overview of the four roles available in Novu:

--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -4,7 +4,7 @@ description: 'Learn about roles and permissions in Novu'
 ---
 Novu uses a role-based access control (RBAC) model at the organization level. Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard.
 
-You assign a role to a team member when you invite them to your Novu organization. You can later update their role from the Team section in your organization settings.
+You assign a role to a team member when you invite them to your Novu organization. You can later update their role from the [Team section](https://dashboard.novu.co/settings/team) in your organization settings.
 
 Below is an overview of the four roles available in Novu:
 - **Owner**. For your primary account administrator. This role has full access across the platform, including organization-level settings, billing, API keys, environment management, and user administration. Each Novu organization must have at least one owner.

--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -2,7 +2,7 @@
 title: 'Roles and persmissions'
 description: 'Learn about roles and permissions in Novu'
 ---
-Novu uses a role-based access control (RBAC) model at the organization level. Each member in your Novu account is assigned a role that determines the actions they can perform within the Novu dashboard.
+Novu uses a role-based access control (RBAC) model at the organization level. Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard.
 
 You assign a role to a team member when you invite them to your Novu organization. You can later update their role from the Team section in your organization settings.
 

--- a/content/docs/platform/meta.json
+++ b/content/docs/platform/meta.json
@@ -43,6 +43,7 @@
     "additional-resources/glossary",
     "additional-resources/limits",
     "additional-resources/security",
+    "additional-resources/roles-and-permissions",
     "additional-resources/v0"
   ],
   "root": true


### PR DESCRIPTION
## Add New RBAC (Role-Based Access Control) Documentation Page
**Summary:**
This PR adds a new documentation page introducing the Role-Based Access Control (RBAC) feature. It outlines the available roles in Novu (Viewer, Author, Admin, Owner) and clearly presents the permissions associated with each role using a human-readable access table.

**What's included:**
- New dedicated page for RBAC under the appropriate section
- A roles and permissions table, alphabetically organized for quick scanning
- Icon legend for intuitive understanding of access levels (📖 Read, ✅ Write, ❌ No access)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a new page explaining roles and permissions, detailing the role-based access control model, available roles, and their specific permissions within the platform.
  - Updated the documentation navigation to include the new roles and permissions page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->