### PR TITLE
Fix RBAC page icon

### DIFF
--- a/content/docs/platform/additional-resources/roles-and-permissions.mdx
+++ b/content/docs/platform/additional-resources/roles-and-permissions.mdx
@@ -1,8 +1,7 @@
 ---
 title: 'Roles and permissions'
 description: 'Learn how roles and permissions are managed within Novu organizations'
-icon: user-lock
-
+icon: 'UserCheck'
 ---
 Novu uses a role-based access control (RBAC) model at the [organization level](/platform/how-novu-works#organization-and-environments). Each member in the organization is assigned a role that determines the actions they can perform within the Novu dashboard. Every user can belong to more than one organization, each with separate configurations and permissions.
 


### PR DESCRIPTION
Change the icon from `UserLock` to `UserCheck`. The `UserLock` icon wasn’t displaying.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the icon displayed in the Roles and Permissions documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->