### PR TITLE
Fix manage members page to appear on the section

### DIFF
--- a/content/docs/platform/meta.json
+++ b/content/docs/platform/meta.json
@@ -34,6 +34,7 @@
     "---Account---",
     "account/authentication",
     "account/roles-and-permissions",
+    "account/manage-members",
     "account/billing",
     "account/sso",
     "---SDKs---",


### PR DESCRIPTION
The PR is to fix the manage members page position on the account section sidebar.