### PR TITLE
fix: update API reference links in documentation

### DIFF
--- a/content/docs/api-reference/integrations/integration-schema.mdx
+++ b/content/docs/api-reference/integrations/integration-schema.mdx
@@ -4,6 +4,8 @@ title: Integration schema
 
 ### Integration
 
+Integration is third party service used by Novu to send notification for a specific channel. For example, [sengrid](/platform/integrations/email/sendgrid) is a email integration and [twilio](/platform/integrations/sms/twilio) is a sms integration. Read more about integrations on [integrations concept page](/platform/concepts/integrations). 
+
 <TypeTable name="Integration" type={{
   "id": {
     "description": "The unique identifier of the integration record in the database. This is automatically generated.",
@@ -64,6 +66,8 @@ title: Integration schema
 }} />
 
 ### Credentials
+
+Each integration has a set of credentials that are used to authenticate with the third party service. Checkout the provider documentation for more details on what credentials are required for each integration.
 
 <TypeTable name="Credentials" type={{
   "apiKey": {
@@ -237,6 +241,8 @@ title: Integration schema
 }} />
 
 ### ChannelTypeEnum
+
+ChannelTypeEnum is used to specify the type of channel that the integration is used for. For example, if the integration is used for email, the channel type will be `email`.
 
 ```typescript
 ChannelTypeEnum {

--- a/content/docs/api-reference/integrations/integration-schema.model.mdx
+++ b/content/docs/api-reference/integrations/integration-schema.model.mdx
@@ -4,17 +4,23 @@ title: Integration schema
 
 ### Integration
 
+Integration is third party service used by Novu to send notification for a specific channel. For example, [sengrid](/platform/integrations/email/sendgrid) is a email integration and [twilio](/platform/integrations/sms/twilio) is a sms integration. Read more about integrations on [integrations concept page](/platform/concepts/integrations). 
+
 ---type-table---
 ../api-types.ts#Integration
 ---end---
 
 ### Credentials
 
+Each integration has a set of credentials that are used to authenticate with the third party service. Checkout the provider documentation for more details on what credentials are required for each integration.
+
 ---type-table---
 ../api-types.ts#Credentials
 ---end---
 
 ### ChannelTypeEnum
+
+ChannelTypeEnum is used to specify the type of channel that the integration is used for. For example, if the integration is used for email, the channel type will be `email`.
 
 ```typescript
 ChannelTypeEnum {

--- a/content/docs/api-reference/messages/message-schema.mdx
+++ b/content/docs/api-reference/messages/message-schema.mdx
@@ -4,6 +4,8 @@ title: Message schema
 
 ### Message
 
+Message is a single notification that is sent to a subscriber. Each channel step in the workflow generates a message.
+
 <TypeTable name="Message" type={{
   "id": {
     "description": "Unique identifier for the message",
@@ -156,6 +158,8 @@ ChannelTypeEnum {
 
 ### Workflow
 
+Workflow is a collection of steps that are executed in order to send a notification.
+
 <TypeTable name="Workflow" type={{
   "id": {
     "description": "",
@@ -245,6 +249,8 @@ ChannelTypeEnum {
 
 ### Actor
 
+Actor is the user who is skipped from sending the notification when workflow is triggered to a [topic](/platform/concepts/topics).
+
 <TypeTable name="Actor" type={{
   "toString": {
     "description": "",
@@ -257,6 +263,8 @@ ChannelTypeEnum {
 }} />
 
 ### MessageCTA
+
+MessageCTA is a call to action that is displayed in the [Inbox](/platform/inbox/overview) message. It can be used to redirect the user to a specific URL when the message is clicked.
 
 <TypeTable name="MessageCTA" type={{
   "type": {

--- a/content/docs/api-reference/messages/message-schema.model.mdx
+++ b/content/docs/api-reference/messages/message-schema.model.mdx
@@ -4,6 +4,8 @@ title: Message schema
 
 ### Message
 
+Message is a single notification that is sent to a subscriber. Each channel step in the workflow generates a message.
+
 ---type-table---
 ../api-types.ts#Message
 ---end---
@@ -21,17 +23,23 @@ ChannelTypeEnum {
 
 ### Workflow
 
+Workflow is a collection of steps that are executed in order to send a notification.
+
 ---type-table---
 ../api-types.ts#Workflow
 ---end---
 
 ### Actor
 
+Actor is the user who is skipped from sending the notification when workflow is triggered to a [topic](/platform/concepts/topics).
+
 ---type-table---
 ../api-types.ts#Actor
 ---end---
 
 ### MessageCTA
+
+MessageCTA is a call to action that is displayed in the [Inbox](/platform/inbox/overview) message. It can be used to redirect the user to a specific URL when the message is clicked.
 
 ---type-table---
 ../api-types.ts#MessageCTA

--- a/content/docs/platform/concepts/notifications.mdx
+++ b/content/docs/platform/concepts/notifications.mdx
@@ -20,7 +20,7 @@ A notification doesn't exist in isolation, it’s the result of a sequence of in
 
 ### Event
 
-Something meaningful happens in your application, such as a user signing up, a password reset being requested, or a comment being posted. You emit this event to Novu using the [Event Trigger API](/api-reference/events/trigger/post).
+Something meaningful happens in your application, such as a user signing up, a password reset being requested, or a comment being posted. You emit this event to Novu using the [Event Trigger API](/api-reference/events/trigger-event).
 
 Each event contains:
 - A name that maps to a specific workflow (user_signed_up)
@@ -65,7 +65,7 @@ Messages are live entities, tracked in real-time, with full visibility into:
 - Delivery status
 - Provider responses or errors
 
-<Callout>Each message has its own ID and status, and you can query it via the [Message API](/api-reference/messages/messages/get).</Callout>
+<Callout>Each message has its own ID and status, and you can query it via the [Message API](/api-reference/messages/list-all-messages).</Callout>
 
 ## Notification structure
 
@@ -85,4 +85,4 @@ Each notification encapsulates a set of properties that describe its creation, c
 | `messages`      | The individual messages generated for each channel. Contains delivery status, content, and provider response.                               |
 | `status`        | The current execution state of the notification (`pending`, `completed`, `failed`, and so on).                                                   |
 
-These fields are accessible via the [Notifications API](/api-reference/notifications/notifications/get) and are also displayed in the Novu dashboard’s Activity Feed for visual traceability.
+These fields are accessible via the [Notifications API](/api-reference/notifications/list-all-events) and are also displayed in the Novu dashboard’s Activity Feed for visual traceability.

--- a/content/docs/platform/concepts/topics.mdx
+++ b/content/docs/platform/concepts/topics.mdx
@@ -57,7 +57,7 @@ This auto-generated topic can then be renamed and managed just like any other to
 
 ## Explore the topics API
 
-For implementation details and usage examples, visit the [Topics API reference](/api-reference/topics/topics/get).
+For implementation details and usage examples, visit the [Topics API reference](/topics/topic-schema).
 
 ## Frequently asked questions
 

--- a/content/docs/platform/concepts/trigger.mdx
+++ b/content/docs/platform/concepts/trigger.mdx
@@ -50,7 +50,7 @@ Jobs play a crucial role in the trigger event lifecycle. They are created based 
 
 ### What is an event?
 
-An event is a request (for instance, an API call to [/v1/events/trigger](/api-reference/events/events-controller_trigger)) that starts off an action in the Novu Workflow Engine. Events can make many different types of actions, including digests, delays, and sending notifications to various channels, as well as filters and user preference checks.
+An event is a request (for instance, an API call to [/v1/events/trigger](/api-reference/events/trigger-event)) that starts off an action in the Novu Workflow Engine. Events can make many different types of actions, including digests, delays, and sending notifications to various channels, as well as filters and user preference checks.
 
 ### How events are billed?
 

--- a/content/docs/platform/integrations/chat/(providers)/discord.mdx
+++ b/content/docs/platform/integrations/chat/(providers)/discord.mdx
@@ -55,7 +55,7 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 - `subscriberId` is a custom identifier used when identifying your users within the Novu platform.
 - `providerId` is a unique provider identifier. We recommend using our ChatProviderIdEnum to specify the provider.

--- a/content/docs/platform/integrations/chat/(providers)/ms-teams.mdx
+++ b/content/docs/platform/integrations/chat/(providers)/ms-teams.mdx
@@ -7,7 +7,7 @@ import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
 
 MS Teams does not need any `API Key` or `Client ID` to send notifications. Our current implementation is based on the [Incoming Webhook URL](https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook?tabs=newteams%2Cjavascript). It is a URL that you can use to send messages to a specific channel. This URL needs to be stored on the subscriber entity
 
-Similar to [Discord](/platform/integrations/chat/discord), the credential for this provider needs to be stored in the [subscriber entity](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel).
+Similar to [Discord](/platform/integrations/chat/discord), the credential for this provider needs to be stored in the [subscriber entity](/api-reference/subscribers/update-provider-credentials).
 
 ## Creating incoming webhook URL
 
@@ -54,8 +54,8 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 - `subscriberId` is a custom identifier used when identifying your users within the Novu platform.
 - `providerId` is a unique provider identifier. We recommend using our ChatProviderIdEnum to specify the provider.
-- The third parameter is the credentials object, in this case, we use the `webhookUrl` property to specify the MS Teams channel webhook URL or by calling the `Update Subscriber Credentials` endpoint on Novu API. Check endpoint details [here](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel).
+- The third parameter is the credentials object, in this case, we use the `webhookUrl` property to specify the MS Teams channel webhook URL or by calling the `Update Subscriber Credentials` endpoint on Novu API. Check endpoint details [here](/api-reference/subscribers/update-provider-credentials).

--- a/content/docs/platform/integrations/chat/(providers)/slack.mdx
+++ b/content/docs/platform/integrations/chat/(providers)/slack.mdx
@@ -128,7 +128,7 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 - `subscriberId` is a custom identifier used when identifying your users within the Novu platform.
 - `providerId` is a unique provider identifier. We recommend using our ChatProviderIdEnum.Slack if you're using Node, else string of Slack to specify the provider.

--- a/content/docs/platform/integrations/chat/(providers)/zulip.mdx
+++ b/content/docs/platform/integrations/chat/(providers)/zulip.mdx
@@ -74,6 +74,6 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 
 - `subscriberId` is a custom identifier used when identifying your users within the Novu platform.
 - `providerId` is a unique provider identifier. We recommend using our ChatProviderIdEnum to specify the provider.
-- The third parameter is the credentials object, in this case, we use the `webhookUrl` property to specify the MS Teams channel webhook URL or by calling the `Update Subscriber Credentials` endpoint on Novu API. Check endpoint details [here](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel).
+- The third parameter is the credentials object, in this case, we use the `webhookUrl` property to specify the MS Teams channel webhook URL or by calling the `Update Subscriber Credentials` endpoint on Novu API. Check endpoint details [here](/api-reference/subscribers/update-provider-credentials).
 
 3. You are all set up and ready to send your first chat message via our `@novu/node` package or directly using the REST API.

--- a/content/docs/platform/integrations/chat/adding-chat.mdx
+++ b/content/docs/platform/integrations/chat/adding-chat.mdx
@@ -85,7 +85,7 @@ This step can be skipped if you already have a subscriber. You can use the `subs
 </Step>
 
 <Step title="Update Subscriber Credentials">
-  [Update](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) the
+  [Update](/api-reference/subscribers/update-provider-credentials) the
   subscriber credential `webhookUrl` for this provider and integration.
 </Step>
 

--- a/content/docs/platform/integrations/chat/index.mdx
+++ b/content/docs/platform/integrations/chat/index.mdx
@@ -70,7 +70,7 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 <Callout type="info">
   Integration identifier is similar to Provider identifier but it is different than Provider Id. It
@@ -85,6 +85,6 @@ Common erros and reason of those errors while sending chat messages using Novu.
 - Subscriber does not have a configured channel
   - if the subscriber does not have credentials set up for any of the chat provider
 - Webhook URL for the chat channel is missing
-  - `webhookUrl` field is null, undefined or not set. Check using [get subscriber api](/api-reference/subscribers/subscribers-controller_get-subscriber)
+  - `webhookUrl` field is null, undefined or not set. Check using [get subscriber api](/api-reference/subscribers/retrieve-a-subscriber)
 - Subscriber does not have an active integration
   - if subscriber have credentials set but integration is either not active or deleted for this credential

--- a/content/docs/platform/integrations/push/(providers)/apns.mdx
+++ b/content/docs/platform/integrations/push/(providers)/apns.mdx
@@ -107,7 +107,7 @@ await novu.subscribers.setCredentials('subscriberId', PushProviderIdEnum.APNS, {
 deviceTokens: ['token1', 'token2'],
 });
 
-````
+```
 </Tab>
 <Tab value="cURL">
 ```bash
@@ -120,9 +120,8 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
   "deviceTokens": ["token1", "token2"],
   "integrationIdentifier": "apns-MnGLxp8uy"
 }'
-````
-
+```
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.

--- a/content/docs/platform/integrations/push/(providers)/expo-push.mdx
+++ b/content/docs/platform/integrations/push/(providers)/expo-push.mdx
@@ -41,7 +41,7 @@ await novu.subscribers.setCredentials('subscriberId', PushProviderIdEnum.EXPO, {
   deviceTokens: ['token1', 'token2'],
 });
 
-````
+```
 </Tab>
 <Tab value="cURL">
 ```bash
@@ -59,4 +59,4 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.

--- a/content/docs/platform/integrations/push/(providers)/fcm.mdx
+++ b/content/docs/platform/integrations/push/(providers)/fcm.mdx
@@ -95,7 +95,7 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 ## SDK Trigger Example
 

--- a/content/docs/platform/integrations/push/(providers)/onesignal.mdx
+++ b/content/docs/platform/integrations/push/(providers)/onesignal.mdx
@@ -50,7 +50,7 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 ## SDK Trigger Example
 

--- a/content/docs/platform/integrations/push/(providers)/push-webhook.mdx
+++ b/content/docs/platform/integrations/push/(providers)/push-webhook.mdx
@@ -54,7 +54,7 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
   </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 ## Example paylod sent by novu to webhook url
 

--- a/content/docs/platform/integrations/push/(providers)/pusher-beams.mdx
+++ b/content/docs/platform/integrations/push/(providers)/pusher-beams.mdx
@@ -34,7 +34,7 @@ await novu.subscribers.setCredentials('subscriberId', PushProviderIdEnum.PusherB
   deviceTokens: ['userId-from-pusher-beams'],
 });
 
-````
+```
 </Tab>
 <Tab value="cURL">
 ```bash
@@ -47,12 +47,12 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
   "deviceTokens": ['userId-from-pusher-beams'],
   "integrationIdentifier": "pusher-beams-MnGLxp8uy"
 }'
-````
+```
 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 ## SDK Trigger Example
 

--- a/content/docs/platform/integrations/push/(providers)/pushpad.mdx
+++ b/content/docs/platform/integrations/push/(providers)/pushpad.mdx
@@ -52,7 +52,7 @@ curl -L -X PUT 'https://api.novu.co/v1/subscribers/<SUBSCRIBER_ID>/credentials' 
 </Tab>
 </Tabs>
 
-Checkout the [API reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) for more details.
+Checkout the [API reference](/api-reference/subscribers/update-provider-credentials) for more details.
 
 ## SDK Trigger Example
 

--- a/content/docs/platform/integrations/push/index.mdx
+++ b/content/docs/platform/integrations/push/index.mdx
@@ -79,7 +79,7 @@ novu.trigger('workflow-id', {
 
 ### Manual
 
-Use the Novu Set Credentials API to update subscriber profiles with device tokens. You can read more about the API in the [API Reference](/api-reference/subscribers/subscribers-v1-controller_update-subscriber-channel) or the [FCM Example](/platform/integrations/push/fcm#setting-device-token)
+Use the Novu Set Credentials API to update subscriber profiles with device tokens. You can read more about the API in the [API Reference](/api-reference/subscribers/update-provider-credentials) or the [FCM Example](/platform/integrations/push/fcm#setting-device-token)
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
- Corrected links in notifications, topics, trigger, and chat integration documentation to point to the updated API reference endpoints.
- Ensured consistency across various provider documentation for chat and push integrations by updating subscriber credential links.
- Added detailed descriptions for integration, credentials, channel types, message, workflow, actor, and message CTA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated multiple API reference links across platform and integration documentation to reflect current endpoints.
  - Corrected code block formatting in several push provider integration guides for improved readability.
  - Ensured all references to updating subscriber credentials use the latest API documentation URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->