### PR TITLE
Changed the presentation of the customize icons docs

### DIFF
--- a/content/docs/platform/inbox/react/styling.mdx
+++ b/content/docs/platform/inbox/react/styling.mdx
@@ -137,7 +137,8 @@ const appearance = {
 
 The `icons` property in the `appearance` prop lets you customize any icon used in the Inbox component. This is useful when you want to:
 - Match the bell icon with your host app's navbar icon set.
-- Use your own icon library, such as <a href="https://react-icons.github.io/react-icons/">react-icons</a> or <a href="https://mui.com/material-ui/material-icons/">Material Icons</a>.
+– Use your own icon library, such as [react-icons](https://react-icons.github.io/react-icons/) or [Material Icons](https://mui.com/material-ui/material-icons/).
+
 - Modify all icons to fit your application's visual style.
 
 For each icon you want to customize, provide a function that returns your custom icon as a React component.

--- a/content/docs/platform/inbox/react/styling.mdx
+++ b/content/docs/platform/inbox/react/styling.mdx
@@ -137,16 +137,10 @@ const appearance = {
 
 The `icons` property in the `appearance` prop lets you customize any icon used in the Inbox component. This is useful when you want to:
 - Match the bell icon with your host app's navbar icon set
-- Use your own icon library, such as <a href="https://react-icons.github.io/react-icons/">react-icons</a> or <a href="https://mui.com/material-ui/material-icons/">Material Icons</a> to maintain a consistent design system
+- Use your own icon library, such as <a href="https://react-icons.github.io/react-icons/">react-icons</a> or <a href="https://mui.com/material-ui/material-icons/">Material Icons</a>
 - Modify all icons to fit your application's visual style
 
-
-#### Finding icon keys
-Each icon in the Inbox component is identified by a unique key. To find the key for a specific icon, inspect the element in your browser’s developer tools. Icon elements include a class name that starts with `nv-` and often feature a 🖼️ emoji for easier identification. 
-
-The portion of the class name following `nv-` is the icon key. For example, an element with the class `nv-cogs` has the icon key `cogs`, which you can use in the `appearance.icons` property to override that icon with a custom renderer.
-
-Once you’ve identified the key, provide a function that returns a React component to replace the default icon:
+You can customize icons by providing a function that returns a React component for each icon key you want to change.
 
 ```tsx
 import { Inbox } from '@novu/react';
@@ -171,113 +165,38 @@ export function Novu() {
 }
 ```
 
-This lets you fully customize the visual presentation of the Inbox component’s icons using your preferred design system.
+#### List of customizable icon keys
 
+Use these keys in the `appearance.icons` property to customize specific icons in the Inbox component:
 
-#### Available icon keys
+| Icon Key             | Description                                          |
+| -------------------- | ---------------------------------------------------- |
+| `arrowDown`          | Down arrow used in dropdowns and expandable sections |
+| `arrowDropDown`      | Dropdown arrow in menus and selectors                |
+| `arrowLeft`          | Left arrow used in pagination and navigation         |
+| `arrowRight`         | Right arrow used in pagination and navigation        |
+| `bell`               | Notification bell icon in the header                 |
+| `chat`               | Chat channel icon in notification preferences        |
+| `check`              | Checkmark icon used for selected items               |
+| `clock`              | Date/time display for notifications                  |
+| `cogs`               | Settings/preferences icon in the header              |
+| `dots`               | More options menu (three dots) in notification items |
+| `email`              | Email channel icon in notification preferences       |
+| `inApp`              | In-app channel icon in notification preferences      |
+| `markAsArchived`     | Icon for archiving notifications                     |
+| `markAsArchivedRead` | Icon for marking notifications as archived and read  |
+| `markAsRead`         | Icon for marking notifications as read               |
+| `markAsUnread`       | Icon for marking notifications as unread             |
+| `markAsUnarchived`   | Icon for unarchiving notifications                   |
+| `push`               | Push notification channel icon in preferences        |
+| `sms`                | SMS channel icon in notification preferences         |
+| `trash`              | Delete/remove icon for notifications                 |
+| `unread`             | Indicator for unread notifications                   |
+| `unsnooze`           | Icon for unsnoozed notifications                     |
 
-<details>
-  <summary>Click to view all available icon keys</summary>
-  <table>
-    <thead>
-      <tr>
-        <th>Icon Key</th>
-        <th>Description</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td><code>bell</code></td>
-        <td>The notification bell icon in the header</td>
-      </tr>
-      <tr>
-        <td><code>clock</code></td>
-        <td>Used in the date/time display for notifications</td>
-      </tr>
-      <tr>
-        <td><code>arrowDropDown</code></td>
-        <td>Dropdown arrow in various menus and selectors</td>
-      </tr>
-      <tr>
-        <td><code>dots</code></td>
-        <td>More options menu (three dots) in notification items</td>
-      </tr>
-      <tr>
-        <td><code>markAsRead</code></td>
-        <td>Icon for marking notifications as read</td>
-      </tr>
-      <tr>
-        <td><code>cogs</code></td>
-        <td>Settings/preferences icon in the header</td>
-      </tr>
-      <tr>
-        <td><code>trash</code></td>
-        <td>Delete/remove icon for notifications</td>
-      </tr>
-      <tr>
-        <td><code>markAsArchived</code></td>
-        <td>Icon for archiving notifications</td>
-      </tr>
-      <tr>
-        <td><code>markAsArchivedRead</code></td>
-        <td>Icon for marking notifications as archived and read</td>
-      </tr>
-      <tr>
-        <td><code>markAsUnread</code></td>
-        <td>Icon for marking notifications as unread</td>
-      </tr>
-      <tr>
-        <td><code>markAsUnarchived</code></td>
-        <td>Icon for unarchiving notifications</td>
-      </tr>
-      <tr>
-        <td><code>unsnooze</code></td>
-        <td>Icon for unsnoozed notifications</td>
-      </tr>
-      <tr>
-        <td><code>arrowRight</code></td>
-        <td>Right arrow used in pagination and navigation</td>
-      </tr>
-      <tr>
-        <td><code>arrowLeft</code></td>
-        <td>Left arrow used in pagination and navigation</td>
-      </tr>
-      <tr>
-        <td><code>unread</code></td>
-        <td>Indicator for unread notifications</td>
-      </tr>
-      <tr>
-        <td><code>sms</code></td>
-        <td>SMS channel icon in notification preferences</td>
-      </tr>
-      <tr>
-        <td><code>inApp</code></td>
-        <td>In-app channel icon in notification preferences</td>
-      </tr>
-      <tr>
-        <td><code>email</code></td>
-        <td>Email channel icon in notification preferences</td>
-      </tr>
-      <tr>
-        <td><code>push</code></td>
-        <td>Push notification channel icon in preferences</td>
-      </tr>
-      <tr>
-        <td><code>chat</code></td>
-        <td>Chat channel icon in notification preferences</td>
-      </tr>
-      <tr>
-        <td><code>check</code></td>
-        <td>Checkmark icon used for selected items</td>
-      </tr>
-      <tr>
-        <td><code>arrowDown</code></td>
-        <td>Down arrow used in dropdowns and expandable sections</td>
-      </tr>
-    </tbody>
-  </table>
-</details>
-
+<Callout type="info">
+You can inspect the Inbox component using your browser’s developer tools to discover icon keys. Icon elements have class names that start with `nv-` and include a 🖼️ emoji for easier identification. The part following `nv-` is the icon key. For example, an element with the class `nv-cogs` has the icon key `cogs`.
+</Callout>
 
 ### Dark theme
 

--- a/content/docs/platform/inbox/react/styling.mdx
+++ b/content/docs/platform/inbox/react/styling.mdx
@@ -14,7 +14,7 @@ The Inbox component is built to allow for multiple layers of styling, which allo
 Depending on the level of customization you need, you can choose to style the inbox using one of the following approaches:
 
 - [Appearance Prop](#appearance-prop)
-  - [Variables](#variables) - Global primitives such as buttons, popovers, dropdowns and etc...
+  - [Variables](#variables) - Global primitives such as buttons, popovers, drop-downs and etc...
   - [Elements](#elements) - Style individual elements
 - [Custom notification rendering](#render-notification-component) - Render a custom notification item with complete control
 - [Custom Composition](/platform/inbox/react/components/overview#composition) - Compose our components for custom layouts
@@ -136,11 +136,11 @@ const appearance = {
 ### Customizing icons
 
 The `icons` property in the `appearance` prop lets you customize any icon used in the Inbox component. This is useful when you want to:
-- Match the bell icon with your host app's navbar icon set
-- Use your own icon library, such as <a href="https://react-icons.github.io/react-icons/">react-icons</a> or <a href="https://mui.com/material-ui/material-icons/">Material Icons</a>
-- Modify all icons to fit your application's visual style
+- Match the bell icon with your host app's navbar icon set.
+- Use your own icon library, such as <a href="https://react-icons.github.io/react-icons/">react-icons</a> or <a href="https://mui.com/material-ui/material-icons/">Material Icons</a>.
+- Modify all icons to fit your application's visual style.
 
-You can customize icons by providing a function that returns a React component for each icon key you want to change.
+For each icon you want to customize, provide a function that returns your custom icon as a React component.
 
 ```tsx
 import { Inbox } from '@novu/react';
@@ -171,8 +171,8 @@ Use these keys in the `appearance.icons` property to customize specific icons in
 
 | Icon Key             | Description                                          |
 | -------------------- | ---------------------------------------------------- |
-| `arrowDown`          | Down arrow used in dropdowns and expandable sections |
-| `arrowDropDown`      | Dropdown arrow in menus and selectors                |
+| `arrowDown`          | Down arrow used in drop-downs and expandable sections |
+| `arrowDropDown`      | Drop-down arrow in menus and selectors                |
 | `arrowLeft`          | Left arrow used in pagination and navigation         |
 | `arrowRight`         | Right arrow used in pagination and navigation        |
 | `bell`               | Notification bell icon in the header                 |


### PR DESCRIPTION
## PR Description: Refactor customizing icons documentation

The current customized icons docs was updated. Mainly to make the available icons section more visible and developer-focused.
- Developers want to customize icons.
- They need to know which keys are available.
- They shouldn’t be forced to reverse-engineer icon keys by inspecting browser dev tools if we can give them a reliable source of truth.
- Removed the “Finding icon keys” section. I made the information there a callout instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Streamlined instructions for customizing icons in the Inbox component for improved clarity.
  - Replaced the collapsible HTML table of icon keys with a simpler markdown-style table.
  - Moved detailed icon key discovery steps into a dedicated informational callout at the end of the section.
  - Simplified example code for overriding icons and refined wording in the Variables section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->