### PR TITLE
fix: standardize shell code block formatting in clone instructions

### DIFF
--- a/content/docs/community/run-in-local-machine.mdx
+++ b/content/docs/community/run-in-local-machine.mdx
@@ -29,9 +29,15 @@ After installing the required services on your machine, you can clone and set up
 1.  Clone the repository
 
 <Tabs items={['Novu Org', 'Forked Repo']}>
-  <Tab value="Novu Org">```shell git clone https://github.com/novuhq/novu.git ```</Tab>
+  <Tab value="Novu Org">
+```shell
+git clone https://github.com/novuhq/novu.git
+```
+  </Tab>
   <Tab value="Forked Repo">
-    ```shell git clone https://github.com/{YOUR_GITHUB_USER_NAME}/novu.git ```
+```shell
+git clone https://github.com/{YOUR_GITHUB_USER_NAME}/novu.git
+```
   </Tab>
 </Tabs>
 

--- a/content/docs/community/run-in-local-machine.mdx
+++ b/content/docs/community/run-in-local-machine.mdx
@@ -116,39 +116,54 @@ The command `npm run setup:project` creates default environment variables that a
   </Accordion>
 
 <Accordion title="Worker">
-  - `NODE_ENV` (default: local)The environment of the app. Possible values are: dev, test,
-  production, ci, local - `PORT`The port on which the Worker app should listen on -
-  `STORE_ENCRYPTION_KEY`The encryption key used to encrypt/decrypt provider credentials -
-  `MAX_NOVU_INTEGRATION_MAIL_REQUESTS`The number of free emails that can be sent with the Novu email
-  provider - `NOVU_EMAIL_INTEGRATION_API_KEY`The Novu email provider Sentry API key -
-  `STORAGE_SERVICE`The storage service name: AWS, GCS, or AZURE - `S3_LOCAL_STACK`The LocalStack
-  service URL - `S3_BUCKET_NAME`The name of the S3 Bucket - `S3_REGION`The AWS region of the S3
-  Bucket - `GCS_BUCKET_NAME`The name of the GCS Bucket - `AZURE_ACCOUNT_NAME`The name of the Azure
-  account - `AZURE_ACCOUNT_KEY`The Azure account key - `AZURE_HOST_NAME`The Azure host name -
-  `AZURE_CONTAINER_NAME`The Azure container name - `AWS_ACCESS_KEY_ID`The AWS access key -
-  `AWS_SECRET_ACCESS_KEY`The AWS secret access key - `REDIS_HOST`The domain / IP of your redis
-  instance - `REDIS_PORT`The port of your redis instance - `REDIS_PASSWORD`Optional password of your
-  redis instance - `REDIS_DB_INDEX`The Redis database index - `REDIS_CACHE_SERVICE_HOST`The domain /
-  IP of your redis instance for caching - `REDIS_CACHE_SERVICE_PORT`The port of your redis instance
-  for caching - `REDIS_DB_INDEX`The Redis cache database index - `REDIS_CACHE_TTL`The Redis cache
-  ttl - `REDIS_CACHE_PASSWORD`The Redis cache password - `REDIS_CACHE_CONNECTION_TIMEOUT`The Redis
-  cache connection timeout - `REDIS_CACHE_KEEP_ALIVE`The Redis cache TCP keep alive on the socket
-  timeout - `REDIS_CACHE_FAMILY`The Redis cache IP stack version - `REDIS_CACHE_KEY_PREFIX`The Redis
-  cache prefix prepend to all keys - `REDIS_CACHE_SERVICE_TLS`The Redis cache TLS connection support
-  - `IN_MEMORY_CLUSTER_MODE_ENABLED`The flag that enables the cluster mode. It might be Redis or
-  ElastiCache cluster, depending on the env variables set for either service. -
-  `ELASTICACHE_CLUSTER_SERVICE_HOST`ElastiCache cluster host -
-  `ELASTICACHE_CLUSTER_SERVICE_PORT`ElastiCache cluster port - `REDIS_CLUSTER_SERVICE_HOST`Redis
-  cluster host - `REDIS_CLUSTER_SERVICE_PORTS`Redis cluster ports - `REDIS_CLUSTER_DB_INDEX`Redis
-  cluster database index - `REDIS_CLUSTER_TTL`Redis cluster ttl - `REDIS_CLUSTER_PASSWORD`Redis
-  cluster password - `REDIS_CLUSTER_CONNECTION_TIMEOUT`Redis cluster connection timeout -
-  `REDIS_CLUSTER_KEEP_ALIVE`Redis cluster TCP keep alive on the socket timeout -
-  `REDIS_CLUSTER_FAMILY`Redis cluster IP stack version - `REDIS_CLUSTER_KEY_PREFIX`Redis cluster
-  prefix prepend to all keys - `MONGO_URL`The URL of your MongoDB instance -
-  `MONGO_MAX_POOL_SIZE`The max pool size of the MongoDB connection - `NEW_RELIC_APP_NAME`The New
-  Relic app name - `NEW_RELIC_LICENSE_KEY`The New Relic license key - `SEGMENT_TOKEN`The Segment
-  Analytics token
-</Accordion>
+    - `NODE_ENV` (default: local) - The environment of the app. Possible values are: dev, test, production, ci, local
+    - `PORT` - The port on which the Worker app should listen on
+    - `STORE_ENCRYPTION_KEY` - The encryption key used to encrypt/decrypt provider credentials
+    - `MAX_NOVU_INTEGRATION_MAIL_REQUESTS` - The number of free emails that can be sent with the Novu email provider
+    - `NOVU_EMAIL_INTEGRATION_API_KEY` - The Novu email provider Sentry API key
+    - `STORAGE_SERVICE` - The storage service name: AWS, GCS, or AZURE
+    - `S3_LOCAL_STACK` - The LocalStack service URL
+    - `S3_BUCKET_NAME` - The name of the S3 Bucket
+    - `S3_REGION` - The AWS region of the S3 Bucket
+    - `GCS_BUCKET_NAME` - The name of the GCS Bucket
+    - `AZURE_ACCOUNT_NAME` - The name of the Azure account
+    - `AZURE_ACCOUNT_KEY` - The Azure account key
+    - `AZURE_HOST_NAME` - The Azure host name
+    - `AZURE_CONTAINER_NAME` - The Azure container name
+    - `AWS_ACCESS_KEY_ID` - The AWS access key
+    - `AWS_SECRET_ACCESS_KEY` - The AWS secret access key
+    - `REDIS_HOST` - The domain / IP of your redis instance
+    - `REDIS_PORT` - The port of your redis instance
+    - `REDIS_PASSWORD` - Optional password of your redis instance
+    - `REDIS_DB_INDEX` - The Redis database index
+    - `REDIS_CACHE_SERVICE_HOST` - The domain / IP of your redis instance for caching
+    - `REDIS_CACHE_SERVICE_PORT` - The port of your redis instance for caching
+    - `REDIS_CACHE_DB_INDEX` - The Redis cache database index
+    - `REDIS_CACHE_TTL` - The Redis cache ttl
+    - `REDIS_CACHE_PASSWORD` - The Redis cache password
+    - `REDIS_CACHE_CONNECTION_TIMEOUT` - The Redis cache connection timeout
+    - `REDIS_CACHE_KEEP_ALIVE` - The Redis cache TCP keep alive on the socket timeout
+    - `REDIS_CACHE_FAMILY` - The Redis cache IP stack version
+    - `REDIS_CACHE_KEY_PREFIX` - The Redis cache prefix prepend to all keys
+    - `REDIS_CACHE_SERVICE_TLS` - The Redis cache TLS connection support
+    - `IN_MEMORY_CLUSTER_MODE_ENABLED` - The flag that enables the cluster mode. It might be Redis or ElastiCache cluster, depending on the env variables set for either service.
+    - `ELASTICACHE_CLUSTER_SERVICE_HOST` - ElastiCache cluster host
+    - `ELASTICACHE_CLUSTER_SERVICE_PORT` - ElastiCache cluster port
+    - `REDIS_CLUSTER_SERVICE_HOST` - Redis cluster host
+    - `REDIS_CLUSTER_SERVICE_PORTS` - Redis cluster ports
+    - `REDIS_CLUSTER_DB_INDEX` - Redis cluster database index
+    - `REDIS_CLUSTER_TTL` - Redis cluster ttl
+    - `REDIS_CLUSTER_PASSWORD` - Redis cluster password
+    - `REDIS_CLUSTER_CONNECTION_TIMEOUT` - Redis cluster connection timeout
+    - `REDIS_CLUSTER_KEEP_ALIVE` - Redis cluster TCP keep alive on the socket timeout
+    - `REDIS_CLUSTER_FAMILY` - Redis cluster IP stack version
+    - `REDIS_CLUSTER_KEY_PREFIX` - Redis cluster prefix prepend to all keys
+    - `MONGO_URL` - The URL of your MongoDB instance
+    - `MONGO_MAX_POOL_SIZE` - The max pool size of the MongoDB connection
+    - `NEW_RELIC_APP_NAME` - The New Relic app name
+    - `NEW_RELIC_LICENSE_KEY` - The New Relic license key
+    - `SEGMENT_TOKEN` - The Segment Analytics token
+  </Accordion>
 
   <Accordion title="Web Client">
     - `REACT_APP_ENVIRONMENT` The environment of the app. Possible values are: dev, test, production, ci, local


### PR DESCRIPTION
### Description 
This PR fixes a formatting issue in the documentation where the git clone command was incorrectly prefixed with shell.

❌ Before
```bash
shell git clone https://github.com/YOUR_USERNAME/docs.git
```

✅ After
```bash
git clone https://github.com/YOUR_USERNAME/docs.git
```

### Why it matters
The previous version was not a valid shell command and could cause confusion or errors when followed directly. This update ensures that users can copy and run the setup instructions without issues.


###  Checklist
- [x] Test code before submitting
- [x] Compiled project before submitting with `pnpm build`

### Screenshot

<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/40781c44-9c44-46c9-a892-d3ee84c68cd3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of code blocks in the "Clone the repository" section for better readability.
  * Reformatted environment variables under the "Worker" section into a clear bulleted list for easier reading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->