### PR TITLE
fix(theme): add disableTransitionOnChange prop to theme provider

### DIFF
--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -13,7 +13,7 @@ export function Provider({ children }: { children: ReactNode }) {
         enabled: false,
       }}
     >
-      <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
         {children}
       </ThemeProvider>
     </RootProvider>


### PR DESCRIPTION
# Description

- Added the `disableTransitionOnChange` prop to the `ThemeProvider` component to prevent unwanted CSS transition animations when switching themes, resulting in a smoother user experience.

# Type of Change

* [x] fix: Bug fix  

# How Has This Been Tested?

* [x] Manual tests  
  - Verified theme toggles without transition flicker in light ↔ dark switches.  
  - Confirmed no regressions in existing theming behavior.

# Checklist

* [x] My changes generate no new warnings  
* [x] My code follows the project's coding style  

# Additional Notes

- No configuration changes are required; the new prop defaults to `true` to disable transitions on theme change automatically.  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Theme changes now occur without triggering CSS transitions, providing a smoother experience when switching themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->