### PR TITLE
chore(docs): update @novu/react-native docs

### DIFF
--- a/content/docs/platform/sdks/react-native/hooks/novu-provider.mdx
+++ b/content/docs/platform/sdks/react-native/hooks/novu-provider.mdx
@@ -15,7 +15,7 @@ Usually, it's placed somewhere in the root of your application, which makes the 
 | subscriberId          | string    | Yes      | The unique identifier of the subscriber                        |
 | applicationIdentifier | string    | Yes      | Your application identifier from Novu                          |
 | subscriberHash        | string    | No       | HMAC encryption hash for the subscriber                        |
-| backendUrl            | string    | No       | Custom backend URL for self-hosted instances                   |
+| apiUrl                | string    | No       | Custom api URL for self-hosted instances                       |
 | socketUrl             | string    | No       | Custom socket URL for self-hosted instances                    |
 | children              | ReactNode | Yes      | The child components that will have access to the Novu context |
 
@@ -48,7 +48,7 @@ Usually, it's placed somewhere in the root of your application, which makes the 
         <NovuProvider
           subscriber="SUBSCRIBER_ID"
           applicationIdentifier="APPLICATION_IDENTIFIER"
-          backendUrl="https://eu.api.novu.co"
+          apiUrl="https://eu.api.novu.co"
           socketUrl="https://eu.ws.novu.co"
         >
           {/* Your app components */}


### PR DESCRIPTION
### Changes

- Since the @novu/react-native just uses `@novu/react/hooks` internally, the docs need to be updated to align with that package. `backendUrl` is deprecated and `apiUrl` should be used

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation to rename the `backendUrl` prop to `apiUrl` in the `NovuProvider` React Native component, including prop descriptions and example usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->