### PR TITLE
chore(docs): specify supported Zod version

### DIFF
--- a/content/docs/framework/controls.mdx
+++ b/content/docs/framework/controls.mdx
@@ -174,7 +174,7 @@ For the full list of parameters, check out the [full SDK reference](/framework/t
 
 You can use **Zod, Class-Validator or JSON Schema** based on your needs.
 
-- **[Zod](https://zod.dev/)** - A TypeScript-first schema declaration and validation library. _(Novu supports Zod v3+)_
+- **[Zod](https://zod.dev/)** - A TypeScript-first schema declaration and validation library. _(Novu supports Zod v3)_
 - **[Class-Validator](https://github.com/typestack/class-validator)** - A TypeScript-first validation library using decorators for OOP-style applications.
 - **[JSON Schema](/framework/schema/json-schema)** - The most popular schema language for defining JSON data structures.
 

--- a/content/docs/framework/controls.mdx
+++ b/content/docs/framework/controls.mdx
@@ -174,7 +174,7 @@ For the full list of parameters, check out the [full SDK reference](/framework/t
 
 You can use **Zod, Class-Validator or JSON Schema** based on your needs.
 
-- **[Zod](https://zod.dev/)** - A TypeScript-first schema declaration and validation library.
+- **[Zod](https://zod.dev/)** - A TypeScript-first schema declaration and validation library. _(Novu supports Zod v3+)_
 - **[Class-Validator](https://github.com/typestack/class-validator)** - A TypeScript-first validation library using decorators for OOP-style applications.
 - **[JSON Schema](/framework/schema/json-schema)** - The most popular schema language for defining JSON data structures.
 

--- a/content/docs/framework/schema/zod.mdx
+++ b/content/docs/framework/schema/zod.mdx
@@ -4,7 +4,7 @@ pageTitle: "Zod"
 description: "Learn how to integrate Zod with Novu Framework"
 ---
 
-Novu Framework allows you to use [Zod](https://zod.dev/) to define the [Control](/framework/controls) and [Payload](/framework/payload) schemas for your workflows. _(Supports Zod v3 and later)_
+Novu Framework allows you to use [Zod](https://zod.dev/) to define the [Control](/framework/controls) and [Payload](/framework/payload) schemas for your workflows. _(Supports Zod v3)_
 
 ## Add Zod to your project
 
@@ -15,7 +15,7 @@ Novu Framework allows you to use [Zod](https://zod.dev/) to define the [Control]
         ```
         
         <Callout type="info">
-          Novu Framework supports Zod v3 and later versions. Make sure you're using a compatible version for optimal performance and feature support.
+          Novu Framework supports Zod v3. Make sure you're using this version for optimal performance and feature support.
         </Callout>
     </Step>
     <Step title="Use Zod in your workflow">

--- a/content/docs/framework/schema/zod.mdx
+++ b/content/docs/framework/schema/zod.mdx
@@ -4,7 +4,7 @@ pageTitle: "Zod"
 description: "Learn how to integrate Zod with Novu Framework"
 ---
 
-Novu Framework allows you to use [Zod](https://zod.dev/) to define the [Control](/framework/controls) and [Payload](/framework/payload) schemas for your workflows.
+Novu Framework allows you to use [Zod](https://zod.dev/) to define the [Control](/framework/controls) and [Payload](/framework/payload) schemas for your workflows. _(Supports Zod v3 and later)_
 
 ## Add Zod to your project
 
@@ -13,6 +13,10 @@ Novu Framework allows you to use [Zod](https://zod.dev/) to define the [Control]
         ```bash
         npm install zod
         ```
+        
+        <Callout type="info">
+          Novu Framework supports Zod v3 and later versions. Make sure you're using a compatible version for optimal performance and feature support.
+        </Callout>
     </Step>
     <Step title="Use Zod in your workflow">
         ```typescript


### PR DESCRIPTION
Add Zod v3+ compatibility information to documentation to clarify version support for users.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNS89H/p1755247591316259?thread_ts=1755247591.316259&cid=D0919LNS89H)

<a href="https://cursor.com/background-agent?bcId=bc-a07e0e3a-0faa-47e0-90ae-2c1bbfd77f6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a07e0e3a-0faa-47e0-90ae-2c1bbfd77f6d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

