### PR TITLE
Update docs on critical workflow filtering fixes: NV-6636

### DIFF
--- a/content/docs/platform/inbox/configuration/preferences.mdx
+++ b/content/docs/platform/inbox/configuration/preferences.mdx
@@ -7,7 +7,7 @@ icon: 'UserCog'
 
 The Preferences interface in the Inbox component lets subscribers customize how they receive notifications. By default, Novu renders a preferences icon inside the Inbox component, giving users access to global and workflow-specific settings directly from the UI.
 
-<Callout type = "info">A workflow marked as "critical" on the Novu dashboard cannot be disabled by the user and will not appear in their preferences UI.</Callout>
+<Callout type = "info">A workflow marked as "critical" on the Novu dashboard cannot be disabled by the user and will not appear in their preferences UI, unless the user has specified WorkflowCriticalityEnum.ALL in the preference they will be filtered out.</Callout>
 
 ![Global preferences](/images/inbox/preferences.gif)
 
@@ -56,7 +56,13 @@ The Inbox UI only displays the channels step used in a given workflow.
 
 ### Filter preferences
 
-Use the `preferenceFilter` prop on the Inbox component to control which workflows are shown in the subscriber preferences list. 
+Use the `preferenceFilter` prop on the Inbox component to control which workflows are shown in the subscriber preferences list. You can filter by tags, severity, and criticality using the `PreferencesFilter` type:
+
+```typescript
+export type PreferencesFilter = Pick<NotificationFilter, 'tags' | 'severity'> & {
+  criticality?: WorkflowCriticalityEnum;
+};
+``` 
 
 This filtering works by matching the tags you provide in the prop with the tags assigned to the workflows. Only that workflow will be seen by the subscriber on their preferences UI.
 

--- a/content/docs/platform/inbox/configuration/preferences.mdx
+++ b/content/docs/platform/inbox/configuration/preferences.mdx
@@ -56,13 +56,7 @@ The Inbox UI only displays the channels step used in a given workflow.
 
 ### Filter preferences
 
-Use the `preferenceFilter` prop on the Inbox component to control which workflows are shown in the subscriber preferences list. You can filter by tags, severity, and criticality using the `PreferencesFilter` type:
-
-```typescript
-export type PreferencesFilter = Pick<NotificationFilter, 'tags' | 'severity'> & {
-  criticality?: WorkflowCriticalityEnum;
-};
-``` 
+Use the `preferenceFilter` prop on the Inbox component to control which workflows are shown in the subscriber preferences list. 
 
 This filtering works by matching the tags you provide in the prop with the tags assigned to the workflows. Only that workflow will be seen by the subscriber on their preferences UI.
 
@@ -75,7 +69,7 @@ function InboxPreferences() {
     <Inbox
       applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
       subscriber="YOUR_SUBSCRIBER_ID"
-      preferencesFilter={{ tags: ['general', 'admin', 'security'] }} />
+      preferencesFilter={{ tags: ['general', 'admin', 'security'], criticality: WorkflowCriticalityEnum.ALL }} />
   );
 }
 


### PR DESCRIPTION
Add a note about filtering critical workflows with `filterPreferences` and include the `PreferencesFilter` type definition to clarify preference filtering behavior.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1757339995624739?thread_ts=1757339995.624739&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-b0460a6f-fcdf-4e2b-8b69-67074e6c1c8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0460a6f-fcdf-4e2b-8b69-67074e6c1c8d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Preference filtering now supports workflow criticality, allowing opt-in visibility of critical workflows in the preferences UI.
- Documentation
  - Updated guidance and examples to show how to include critical workflows in global and per-workflow preference filters.
  - Added a note that critical workflows are hidden from the preferences UI by default unless explicitly included.
- API Changes
  - Expanded the preferences filtering options to accept an optional criticality filter for more granular control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->