### PR TITLE
Document preference sorting with preferenceFilter prop

### DIFF
--- a/content/docs/platform/inbox/configuration/preferences.mdx
+++ b/content/docs/platform/inbox/configuration/preferences.mdx
@@ -130,6 +130,67 @@ function InboxPreferences() {
 export default InboxPreferences;
 ```
 
+### Sort preferences
+
+The `preferenceFilter` prop not only controls which workflows are displayed but also determines their rendering order in the preferences UI. The order of preferences returned from the filtering logic will be preserved when rendering the preferences list.
+
+#### Sorting behavior
+
+When you provide a `preferenceFilter` prop:
+- **With filtering**: Only workflows matching your filter criteria will be shown, and they'll appear in the order they're returned from the filter
+- **Without filtering**: If you omit the `preferenceFilter` prop entirely, all available workflows will be displayed in their default order
+
+The key principle is that **the sequence of preferences returned by your filtering logic directly controls the visual order** in the preferences UI.
+
+#### Example: Custom sorting with tags
+
+You can control the order by specifying tags in your preferred sequence. Workflows will appear in the preferences UI following the same order as the tags array:
+
+```tsx
+import { Inbox } from '@novu/react';
+
+function InboxPreferences() {
+  return (
+    <Inbox
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriber="YOUR_SUBSCRIBER_ID"
+      preferencesFilter={{ 
+        tags: ['security', 'account', 'marketing', 'general'] 
+      }} 
+    />
+  );
+}
+
+export default InboxPreferences;
+```
+
+In this example, workflows tagged with 'security' will appear first, followed by 'account', then 'marketing', and finally 'general' workflows.
+
+#### Example: Combining sorting with criticality
+
+When combining tags and criticality filters, the sorting behavior remains consistent:
+
+```tsx
+import { Inbox, WorkflowCriticalityEnum } from '@novu/react';
+
+function InboxPreferences() {
+  return (
+    <Inbox
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriber="YOUR_SUBSCRIBER_ID"
+      preferencesFilter={{ 
+        tags: ['urgent', 'important', 'general'],
+        criticality: WorkflowCriticalityEnum.ALL 
+      }} 
+    />
+  );
+}
+
+export default InboxPreferences;
+```
+
+This will display workflows in the order: urgent → important → general, including both critical and non-critical workflows for each tag category.
+
 ### Group preferences
 
 Use the `preferenceGroups` prop on the Inbox component to organize workflows into meaningful sections in the subscriber preferences UI.


### PR DESCRIPTION
Add documentation for sorting preferences using the `preferenceFilter` prop to clarify how the return order dictates UI display.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1757501863750109?thread_ts=1757501863.750109&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-12fad7bd-dca4-4b6e-965a-07e5f38ba4b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-12fad7bd-dca4-4b6e-965a-07e5f38ba4b7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

