### PR TITLE
fix: broken bridge endpoint link in framework doc

### DIFF
--- a/content/docs/framework/deployment/production.mdx
+++ b/content/docs/framework/deployment/production.mdx
@@ -6,7 +6,7 @@ description: 'Learn how to deploy your Novu Framework application to production 
 
 ## Networking
 
-Novu Cloud workers will need to be able to communicate with your [Bridge Endpoint](/platform/concepts/endpoint). You will need to ensure that your firewall rules allow traffic from the internet.
+Novu Cloud workers will need to be able to communicate with your [Bridge Endpoint](/framework/endpoint). You will need to ensure that your firewall rules allow traffic from the internet.
 Due to the autoscaling nature of Novu Cloud, we don't have a set of IP Addresses that you can whitelist.
 
 ## Security

--- a/content/docs/framework/introduction.mdx
+++ b/content/docs/framework/introduction.mdx
@@ -1,6 +1,6 @@
 ---
 pageTitle: 'Introduction to Novu Framework'
-title: 'Overview'
+title: 'Introduction'
 description: 'Discover how the Novu Framework empowers you to build, customize, and manage advanced notification workflows with a mix of code and no-code capabilities.'
 ---
 

--- a/content/docs/framework/meta.json
+++ b/content/docs/framework/meta.json
@@ -2,8 +2,8 @@
   "root": true,
   "pages": [
     "---Getting Started---",
-    "introduction",
     "overview",
+    "introduction",
     "quickstart",
 
     "---Core Concepts---",

--- a/content/docs/framework/overview.mdx
+++ b/content/docs/framework/overview.mdx
@@ -1,6 +1,6 @@
 ---
 pageTitle: 'Novu Framework Overview'
-title: 'Introduction'
+title: 'Overview'
 description: "Learn how to extend Novu's capabilities by building custom notification workflows with code using the Novu Framework."
 ---
 

--- a/content/docs/framework/quickstart/meta.json
+++ b/content/docs/framework/quickstart/meta.json
@@ -1,0 +1,3 @@
+{
+  "pages": ["nextjs", "express", "remix", "nestjs", "svelte", "nuxt", "h3", "lambda"]
+}

--- a/content/docs/framework/typescript/steps/inApp.mdx
+++ b/content/docs/framework/typescript/steps/inApp.mdx
@@ -70,7 +70,7 @@ const { seen, read, lastSeenDate, lastReadDate } = await step.inApp('inbox', res
 
 - **Type**: `object`
 - **Required**: No
-- **Description**: The redirect object is used to define the URL to visit when interacting with the notification. This property can be omitted in place of an `onNotificationClick` [handler](/platform/inbox/react/components#handle-notification-click) implemented in the `<Inbox />` component.
+- **Description**: The redirect object is used to define the URL to visit when interacting with the notification. This property can be omitted in place of an `onNotificationClick` [handler](/platform/inbox/advanced-customization/notification-click-behavior#handle-notification-click-events) implemented in the `<Inbox />` component.
 - **Properties**:
   - `url` (string, required): The URL to visit when clicking on the notification.
   - `target` (string): The target attribute specifies where the new window or tab will be opened. Defaults to `_blank`. Supported values: `_self, _blank, _parent, _top, _unfencedTop`.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added Quickstart guides for popular frameworks (Next.js, Express, Remix, NestJS, Svelte, Nuxt, H3, Lambda).
  - Reorganized Getting Started navigation: Overview now precedes Introduction; Quickstart added after Introduction.
  - Retitled pages for clarity, adjusting “Overview” and “Introduction”.
  - Updated links to current locations for Networking bridge endpoint and in-app redirect handler.
  - No functional changes; content updates are limited to titles, navigation, and link targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->