### PR TITLE
Document inbox priority tag sorting

### DIFF
--- a/content/docs/platform/inbox/configuration/preferences.mdx
+++ b/content/docs/platform/inbox/configuration/preferences.mdx
@@ -258,7 +258,7 @@ export default InboxPreferences;
 
 ### Sort preferences
 
-Use the `preferenceSort` prop on the Inbox component to customize the order in which workflows are displayed in the subscriber preferences list. This prop accepts a custom comparison function, similar to JavaScript's `Array.sort()` method.
+Use the `preferencesSort` prop on the Inbox component to customize the order in which workflows are displayed in the subscriber preferences list. This prop accepts a custom comparison function, similar to JavaScript's `Array.sort()` method.
 
 The comparison function receives two preference objects (`a`, `b`) as arguments and should return:
 
@@ -280,7 +280,7 @@ function InboxWithAlphabeticalSort() {
     <Inbox
       applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
       subscriber="YOUR_SUBSCRIBER_ID"
-      preferenceSort={(a, b) => {
+      preferencesSort={(a, b) => {
         const aName = a.workflow?.name?.toLowerCase() || '';
         const bName = b.workflow?.name?.toLowerCase() || '';
         return aName.localeCompare(bName);
@@ -306,7 +306,7 @@ function InboxWithSortedPreferences() {
     <Inbox
       applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
       subscriber="YOUR_SUBSCRIBER_ID"
-      preferenceSort={(a, b) => {
+      preferencesSort={(a, b) => {
         const aName = a.workflow?.name?.toLowerCase() || '';
         const bName = b.workflow?.name?.toLowerCase() || '';
         const aHasPriorityTag = a.workflow?.tags?.includes('priority') || false;
@@ -328,7 +328,7 @@ export default InboxWithSortedPreferences;
 
 #### Sorting within groups
 
-You can use `preferenceSort` together with `preferenceGroups`. In this case, sorting is applied within each group; this lets you both organize workflows into sections and control their order inside those sections.
+You can use `preferencesSort` together with `preferenceGroups`. In this case, sorting is applied within each group; this lets you both organize workflows into sections and control their order inside those sections.
 
 For example, after grouping workflows by their functions, you can then sort the workflows alphabetically within each of those groups.
 
@@ -350,7 +350,7 @@ function InboxWithGroupedAndSortedPreferences() {
           filter: { tags: ['marketing'] },
         },
       ]}
-      preferenceSort={(a, b) => {
+      preferencesSort={(a, b) => {
         const aName = a.workflow?.name?.toLowerCase() || '';
         const bName = b.workflow?.name?.toLowerCase() || '';
         return aName.localeCompare(bName);

--- a/content/docs/platform/inbox/configuration/preferences.mdx
+++ b/content/docs/platform/inbox/configuration/preferences.mdx
@@ -332,7 +332,7 @@ You can use `preferenceSort` together with `preferenceGroups`. In this case, sor
 
 For example, after grouping workflows by their functions, you can then sort the workflows alphabetically within each of those groups.
 
-```ts
+```tsx
 import { Inbox } from '@novu/react';
 
 function InboxWithGroupedAndSortedPreferences() {

--- a/content/docs/platform/inbox/configuration/preferences.mdx
+++ b/content/docs/platform/inbox/configuration/preferences.mdx
@@ -159,8 +159,8 @@ function InboxPreferences() {
       subscriber="YOUR_SUBSCRIBER_ID"
       preferenceGroups={[
         {
-          name: General,
-          filter: { tags: [account] },
+          name: 'General',
+          filter: { tags: ['account'] },
         },
       ]}
     />
@@ -187,7 +187,7 @@ function InboxPreferences() {
       preferenceGroups={[
         {
           name: 'Marketing',
-          filter: { tags: ['marketing'], workflowIds: [workflow-ids] },
+          filter: { tags: ['marketing'], workflowIds: ['workflow-ids'] },
         },
       ]}
     />

--- a/content/docs/platform/inbox/configuration/preferences.mdx
+++ b/content/docs/platform/inbox/configuration/preferences.mdx
@@ -256,6 +256,75 @@ function InboxPreferences() {
 export default InboxPreferences;
 ```
 
+### Sort preferences
+
+Use the `preferenceSort` prop on the Inbox component to customize the order in which workflows are displayed in the subscriber preferences list. This prop accepts a comparison function that follows the same pattern as JavaScript's `Array.sort()` method.
+
+The comparison function receives two preference objects as arguments and should return:
+- A negative number if the first item should come before the second
+- A positive number if the first item should come after the second  
+- Zero if the items are equal
+
+Each preference object contains a `workflow` property with metadata including `name`, `tags`, `slug`, and `identifier`.
+
+#### Sort by priority tag
+
+This example shows how to prioritize workflows with a "priority" tag, placing them at the top of the preferences list, followed by alphabetical sorting:
+
+```tsx
+import { Inbox } from '@novu/react';
+
+function InboxWithSortedPreferences() {
+  return (
+    <Inbox
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriber="YOUR_SUBSCRIBER_ID"
+      preferenceSort={(a, b) => {
+        const aName = a.workflow?.name?.toLowerCase() || '';
+        const bName = b.workflow?.name?.toLowerCase() || '';
+        const aHasPriorityTag = a.workflow?.tags?.includes('priority') || false;
+        const bHasPriorityTag = b.workflow?.tags?.includes('priority') || false;
+        
+        // Priority workflows come first
+        if (aHasPriorityTag && !bHasPriorityTag) return -1;
+        if (!aHasPriorityTag && bHasPriorityTag) return 1;
+        
+        // Then sort alphabetically by name
+        return aName.localeCompare(bName);
+      }}
+    />
+  );
+}
+
+export default InboxWithSortedPreferences;
+```
+
+#### Sort alphabetically
+
+For simple alphabetical sorting by workflow name:
+
+```tsx
+import { Inbox } from '@novu/react';
+
+function InboxWithAlphabeticalSort() {
+  return (
+    <Inbox
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriber="YOUR_SUBSCRIBER_ID"
+      preferenceSort={(a, b) => {
+        const aName = a.workflow?.name?.toLowerCase() || '';
+        const bName = b.workflow?.name?.toLowerCase() || '';
+        return aName.localeCompare(bName);
+      }}
+    />
+  );
+}
+
+export default InboxWithAlphabeticalSort;
+```
+
+<Callout type="info">The `preferenceSort` prop works in combination with `preferenceGroups`. When both are used, sorting is applied within each group.</Callout>
+
 ## Use Preferences outside the Inbox UI
 
 You don’t have to display the Preferences UI inside the default Inbox component. Novu provides two main ways to build a custom preference experience for your subscribers.

--- a/content/docs/platform/inbox/configuration/preferences.mdx
+++ b/content/docs/platform/inbox/configuration/preferences.mdx
@@ -59,7 +59,7 @@ The Inbox UI only displays the channels step used in a given workflow.
 
 ### Filter preferences
 
-Use the `preferenceFilter` prop on the Inbox component to control which workflows are shown in the subscriber preferences list. You can filter workflows based on their assigned tags or their criticality level (critical or non-critical).
+Use the `preferencesFilter` prop on the Inbox component to control which workflows are shown in the subscriber preferences list. You can filter workflows based on their assigned tags or their criticality level (critical or non-critical).
 
 #### Filter by tags
 
@@ -258,18 +258,45 @@ export default InboxPreferences;
 
 ### Sort preferences
 
-Use the `preferenceSort` prop on the Inbox component to customize the order in which workflows are displayed in the subscriber preferences list. This prop accepts a comparison function that follows the same pattern as JavaScript's `Array.sort()` method.
+Use the `preferenceSort` prop on the Inbox component to customize the order in which workflows are displayed in the subscriber preferences list. This prop accepts a custom comparison function, similar to JavaScript's `Array.sort()` method.
 
-The comparison function receives two preference objects as arguments and should return:
-- A negative number if the first item should come before the second
-- A positive number if the first item should come after the second  
-- Zero if the items are equal
+The comparison function receives two preference objects (`a`, `b`) as arguments and should return:
 
-Each preference object contains a `workflow` property with metadata including `name`, `tags`, `slug`, and `identifier`.
+- A negative number if `a` should come before `b`.
+- A positive number if `b` should come before `a`.
+- Zero if the order of `a` and `b` doesn't matter.
+
+Each preference object contains a `workflow` property with metadata you can use for sorting, such as `name`, `tags`, `slug`, and `identifier`.
+
+#### Sort alphabetically
+
+You can sort workflows alphabetically by name in the preferences UI
+
+```tsx
+import { Inbox } from '@novu/react';
+
+function InboxWithAlphabeticalSort() {
+  return (
+    <Inbox
+      applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
+      subscriber="YOUR_SUBSCRIBER_ID"
+      preferenceSort={(a, b) => {
+        const aName = a.workflow?.name?.toLowerCase() || '';
+        const bName = b.workflow?.name?.toLowerCase() || '';
+        return aName.localeCompare(bName);
+      }}
+    />
+  );
+}
+
+export default InboxWithAlphabeticalSort;
+```
 
 #### Sort by priority tag
 
-This example shows how to prioritize workflows with a "priority" tag, placing them at the top of the preferences list, followed by alphabetical sorting:
+You can implement more complex logic to meet your specific needs. This example prioritizes workflows tagged with "priority", placing them at the top of the list. All other workflows are then sorted alphabetically by name.
+
+
 
 ```tsx
 import { Inbox } from '@novu/react';
@@ -299,18 +326,30 @@ function InboxWithSortedPreferences() {
 export default InboxWithSortedPreferences;
 ```
 
-#### Sort alphabetically
+#### Sorting within groups
 
-For simple alphabetical sorting by workflow name:
+You can use `preferenceSort` together with `preferenceGroups`. In this case, sorting is applied within each group; this lets you both organize workflows into sections and control their order inside those sections.
 
-```tsx
+For example, after grouping workflows by their functions, you can then sort the workflows alphabetically within each of those groups.
+
+```ts
 import { Inbox } from '@novu/react';
 
-function InboxWithAlphabeticalSort() {
+function InboxWithGroupedAndSortedPreferences() {
   return (
     <Inbox
       applicationIdentifier="YOUR_APPLICATION_IDENTIFIER"
       subscriber="YOUR_SUBSCRIBER_ID"
+      preferenceGroups={[
+        {
+          name: 'Account Notifications',
+          filter: { tags: ['account'] },
+        },
+        {
+          name: 'Marketing Updates',
+          filter: { tags: ['marketing'] },
+        },
+      ]}
       preferenceSort={(a, b) => {
         const aName = a.workflow?.name?.toLowerCase() || '';
         const bName = b.workflow?.name?.toLowerCase() || '';
@@ -320,11 +359,8 @@ function InboxWithAlphabeticalSort() {
   );
 }
 
-export default InboxWithAlphabeticalSort;
+export default InboxWithGroupedAndSortedPreferences;
 ```
-
-<Callout type="info">The `preferenceSort` prop works in combination with `preferenceGroups`. When both are used, sorting is applied within each group.</Callout>
-
 ## Use Preferences outside the Inbox UI
 
 You don’t have to display the Preferences UI inside the default Inbox component. Novu provides two main ways to build a custom preference experience for your subscribers.


### PR DESCRIPTION
Add documentation for the `preferenceSort` prop to allow custom sorting of workflows in Inbox preferences.

---
[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1757662494054519?thread_ts=1757662494.054519&cid=D0919LNRWE7)

<a href="https://cursor.com/background-agent?bcId=bc-adb2ed4a-38c8-4a9a-909f-5d49b52e8173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-adb2ed4a-38c8-4a9a-909f-5d49b52e8173">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added preferencesSort prop to customize how workflows are ordered in subscriber preferences (alphabetical, priority-based, and within groups).
  - Supports sorting within groups when used with preferenceGroups.
  - Renamed inbox prop preferencesFilter for filtering preferences.

- Documentation
  - Updated examples and guidance for sorting preferences with multiple snippets and adjusted sample data to match prop names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->