### PR TITLE
Improve markdown availability for agent friendliness

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -27,6 +27,17 @@ const config = {
 
   // Increase static generation timeout for Netlify
   staticPageGenerationTimeout: 180,
+
+  async rewrites() {
+    const prefixes = ['platform', 'framework', 'community', 'api-reference', 'guides'];
+    const extensions = ['md', 'mdx'];
+    return prefixes.flatMap((prefix) =>
+      extensions.map((ext) => ({
+        source: `/${prefix}/:path*.${ext}`,
+        destination: `/llms.mdx/${prefix}/:path*`,
+      }))
+    );
+  },
 };
 
 export default withMDX(config);

--- a/src/app/[[...slug]]/page.tsx
+++ b/src/app/[[...slug]]/page.tsx
@@ -121,7 +121,7 @@ export default async function Page(props: {
           style: 'clerk',
           footer: isOverviewPage ? null : (
             <PageActions
-              pageContent={rawMarkdownContent}
+              markdownUrl={`${page.url}.mdx`}
               title={page.data.pageTitle ?? page.data.title}
               githubUrl={githubUrl}
               path={page.file.path}
@@ -270,6 +270,9 @@ export async function generateMetadata(props: { params: Promise<{ slug?: string[
       description,
       alternates: {
         canonical: page.url,
+        types: {
+          'text/markdown': `${page.url}.md`,
+        },
       },
       openGraph: {
         type: 'article',

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,0 +1,13 @@
+import { source } from '@/lib/source';
+import { getLLMText } from '@/lib/get-llm-text';
+
+export const revalidate = false;
+
+export async function GET() {
+  const scan = source.getPages().map(getLLMText);
+  const scanned = await Promise.all(scan);
+
+  return new Response(scanned.join('\n\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+  });
+}

--- a/src/app/llms-full.txt/route.ts
+++ b/src/app/llms-full.txt/route.ts
@@ -1,7 +1,7 @@
 import { source } from '@/lib/source';
 import { getLLMText } from '@/lib/get-llm-text';
 
-export const revalidate = false;
+export const dynamic = 'force-static';
 
 export async function GET() {
   const scan = source.getPages().map(getLLMText);

--- a/src/app/llms.mdx/[[...slug]]/route.ts
+++ b/src/app/llms.mdx/[[...slug]]/route.ts
@@ -1,0 +1,22 @@
+import { getLLMText } from '@/lib/get-llm-text';
+import { source } from '@/lib/source';
+import { notFound } from 'next/navigation';
+
+export const revalidate = false;
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ slug?: string[] }> }
+) {
+  const { slug } = await params;
+  const page = source.getPage(slug);
+  if (!page) notFound();
+
+  return new Response(await getLLMText(page), {
+    headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
+  });
+}
+
+export function generateStaticParams() {
+  return source.generateParams();
+}

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -32,7 +32,11 @@ export function GET() {
       const rawDesc =
         typeof page.data.description === 'string' ? page.data.description : '';
       const desc = plainTextFromMarkdownDescription(rawDesc) ?? '';
-      lines.push(desc ? `- [${title}](${page.url}): ${desc}` : `- [${title}](${page.url})`);
+      const markdownUrl = `${page.url}.md`;
+      lines.push(
+        desc ? `- [${title}](${markdownUrl}): ${desc}` : `- [${title}](${markdownUrl})`
+      );
+    }
     }
     lines.push('');
   }

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -22,21 +22,22 @@ export function GET() {
     bySection.set(section, list);
   }
 
-  const lines: string[] = ['# Novu Documentation', '', '> Notification infrastructure for developers.', ''];
+  const lines: string[] = [
+    '# Novu Documentation',
+    '',
+    '> Notification infrastructure for developers.',
+    '',
+  ];
 
   for (const [section, items] of bySection) {
     lines.push(`## ${SECTION_LABELS[section] ?? section}`, '');
     items.sort((a, b) => a.url.localeCompare(b.url));
     for (const page of items) {
       const title = page.data.pageTitle ?? page.data.title;
-      const rawDesc =
-        typeof page.data.description === 'string' ? page.data.description : '';
+      const rawDesc = typeof page.data.description === 'string' ? page.data.description : '';
       const desc = plainTextFromMarkdownDescription(rawDesc) ?? '';
       const markdownUrl = `${page.url}.md`;
-      lines.push(
-        desc ? `- [${title}](${markdownUrl}): ${desc}` : `- [${title}](${markdownUrl})`
-      );
-    }
+      lines.push(desc ? `- [${title}](${markdownUrl}): ${desc}` : `- [${title}](${markdownUrl})`);
     }
     lines.push('');
   }

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,49 +1,43 @@
-import fg from 'fast-glob';
-import { fileGenerator, remarkDocGen, remarkInstall } from 'fumadocs-docgen';
-import { remarkInclude } from 'fumadocs-mdx/config';
-import { remarkAutoTypeTable } from 'fumadocs-typescript';
-import matter from 'gray-matter';
-import * as fs from 'node:fs/promises';
-import { remark } from 'remark';
-import remarkGfm from 'remark-gfm';
-import remarkMdx from 'remark-mdx';
-import remarkStringify from 'remark-stringify';
+import { source } from '@/lib/source';
+import { plainTextFromMarkdownDescription } from '@/lib/plain-text-description';
 
 export const revalidate = false;
 
-const processor = remark()
-  .use(remarkMdx)
-  .use(remarkInclude)
-  .use(remarkGfm)
-  .use(remarkAutoTypeTable)
-  .use(remarkDocGen, { generators: [fileGenerator()] })
-  .use(remarkInstall, { persist: { id: 'package-manager' } })
-  .use(remarkStringify);
+const SECTION_LABELS: Record<string, string> = {
+  platform: 'Platform',
+  framework: 'Framework',
+  community: 'Community',
+  'api-reference': 'API Reference',
+  guides: 'Guides',
+};
 
-export async function GET() {
-  const files = await fg([
-    './content/docs/**/*.mdx',
-    '!./content/docs/openapi/**/*',
-    '!./content/docs/**/*.model.mdx',
-  ]);
+export function GET() {
+  const pages = source.getPages();
 
-  const scan = files.map(async (file) => {
-    const fileContent = await fs.readFile(file);
-    const { content, data } = matter(fileContent.toString());
+  const bySection = new Map<string, typeof pages>();
+  for (const page of pages) {
+    const section = page.slugs[0] ?? 'other';
+    const list = bySection.get(section) ?? [];
+    list.push(page);
+    bySection.set(section, list);
+  }
 
-    const processed = await processor.process({
-      path: file,
-      value: content,
-    });
-    return `file: ${file}
-# ${data.title}
+  const lines: string[] = ['# Novu Documentation', '', '> Notification infrastructure for developers.', ''];
 
-${data.description}
-        
-${processed}`;
+  for (const [section, items] of bySection) {
+    lines.push(`## ${SECTION_LABELS[section] ?? section}`, '');
+    items.sort((a, b) => a.url.localeCompare(b.url));
+    for (const page of items) {
+      const title = page.data.pageTitle ?? page.data.title;
+      const rawDesc =
+        typeof page.data.description === 'string' ? page.data.description : '';
+      const desc = plainTextFromMarkdownDescription(rawDesc) ?? '';
+      lines.push(desc ? `- [${title}](${page.url}): ${desc}` : `- [${title}](${page.url})`);
+    }
+    lines.push('');
+  }
+
+  return new Response(lines.join('\n'), {
+    headers: { 'Content-Type': 'text/plain; charset=utf-8' },
   });
-
-  const scanned = await Promise.all(scan);
-
-  return new Response(scanned.join('\n\n'));
 }

--- a/src/components/page-actions.tsx
+++ b/src/components/page-actions.tsx
@@ -7,22 +7,22 @@ import { ClaudeIcon } from '@/components/icons/claude';
 import { OpenAIIcon } from '@/components/icons/openai';
 
 interface PageActionsProps {
-  pageContent: string;
+  markdownUrl: string;
   title?: string;
   githubUrl?: string;
   path?: string;
 }
 
-export function PageActions({ pageContent, title, githubUrl, path }: PageActionsProps) {
+export function PageActions({ markdownUrl, title, githubUrl, path }: PageActionsProps) {
   const [copied, setCopied] = useState(false);
 
   const handleCopyMarkdown = async () => {
     try {
-      const formattedContent = `# ${title || 'Documentation'}
+      const res = await fetch(markdownUrl);
+      if (!res.ok) throw new Error(`Failed to fetch markdown: ${res.status}`);
+      const markdown = await res.text();
 
-${pageContent}`;
-
-      await navigator.clipboard.writeText(formattedContent);
+      await navigator.clipboard.writeText(markdown);
       setCopied(true);
 
       setTimeout(() => setCopied(false), 2000);

--- a/src/lib/get-llm-text.ts
+++ b/src/lib/get-llm-text.ts
@@ -31,6 +31,7 @@ export async function getLLMText(page: InferPageType<typeof source>) {
     body = String(processed);
   } catch (err) {
     console.error(`[llm-text] failed to process ${page.file.path}:`, err);
+    throw err;
   }
 
   const title = page.data.pageTitle ?? page.data.title;

--- a/src/lib/get-llm-text.ts
+++ b/src/lib/get-llm-text.ts
@@ -1,0 +1,40 @@
+import type { InferPageType } from 'fumadocs-core/source';
+import { fileGenerator, remarkDocGen, remarkInstall } from 'fumadocs-docgen';
+import { remarkInclude } from 'fumadocs-mdx/config';
+import { remarkAutoTypeTable } from 'fumadocs-typescript';
+import matter from 'gray-matter';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { remark } from 'remark';
+import remarkGfm from 'remark-gfm';
+import remarkMdx from 'remark-mdx';
+import remarkStringify from 'remark-stringify';
+import type { source } from './source';
+
+const processor = remark()
+  .use(remarkMdx)
+  .use(remarkInclude)
+  .use(remarkGfm)
+  .use(remarkAutoTypeTable)
+  .use(remarkDocGen, { generators: [fileGenerator()] })
+  .use(remarkInstall, { persist: { id: 'package-manager' } })
+  .use(remarkStringify);
+
+export async function getLLMText(page: InferPageType<typeof source>) {
+  const filePath = path.join(process.cwd(), 'content', 'docs', page.file.path);
+
+  let body = '';
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const { content } = matter(raw);
+    const processed = await processor.process({ path: filePath, value: content });
+    body = String(processed);
+  } catch (err) {
+    console.error(`[llm-text] failed to process ${page.file.path}:`, err);
+  }
+
+  const title = page.data.pageTitle ?? page.data.title;
+  const description = typeof page.data.description === 'string' ? page.data.description : '';
+
+  return `# ${title} (${page.url})\n\n${description}\n\n${body}`;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,17 +2,43 @@ import { clerkMiddleware } from '@clerk/nextjs/server';
 import type { NextFetchEvent, NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 
+function prefersMarkdown(request: NextRequest): boolean {
+  const accept = request.headers.get('accept') ?? '';
+  return accept.includes('text/markdown') || accept.includes('text/x-markdown');
+}
+
 export const config = {
   matcher: [
     // Skip Next.js internals and all static files, unless found in search params
-    '/((?!_next|robots.txt|sitemap.xml|llms.txt|static.json|[^?]*\\.(?:html?|css|js(?!on)|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
+    '/((?!_next|robots.txt|sitemap.xml|llms.txt|llms-full.txt|llms.mdx|static.json|[^?]*\\.(?:html?|css|js(?!on)|mdx?|jpe?g|webp|png|gif|svg|ttf|woff2?|ico|csv|docx?|xlsx?|zip|webmanifest)).*)',
     // Always run for API routes
     '/(api|trpc)(.*)',
   ],
 };
 
+const MARKDOWN_PREFIXES = [
+  '/platform/',
+  '/framework/',
+  '/community/',
+  '/api-reference/',
+  '/guides/',
+];
+
 export default async function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl;
+
+  // Content negotiation: if an AI agent requests markdown via Accept header,
+  // rewrite doc page requests to their .mdx counterpart.
+  if (
+    prefersMarkdown(request) &&
+    MARKDOWN_PREFIXES.some((prefix) => pathname.startsWith(prefix)) &&
+    !pathname.endsWith('.mdx') &&
+    !pathname.endsWith('.md')
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = `${pathname.replace(/\/$/, '')}.mdx`;
+    return NextResponse.rewrite(url);
+  }
 
   // Root redirects
   if (pathname === '/') {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,29 +16,16 @@ export const config = {
   ],
 };
 
-const MARKDOWN_PREFIXES = [
-  '/platform/',
-  '/framework/',
-  '/community/',
-  '/api-reference/',
-  '/guides/',
-];
+const MARKDOWN_SECTIONS = ['/platform', '/framework', '/community', '/api-reference', '/guides'];
+
+function isDocPage(pathname: string): boolean {
+  return MARKDOWN_SECTIONS.some(
+    (section) => pathname === section || pathname.startsWith(`${section}/`)
+  );
+}
 
 export default async function middleware(request: NextRequest, event: NextFetchEvent) {
   const { pathname } = request.nextUrl;
-
-  // Content negotiation: if an AI agent requests markdown via Accept header,
-  // rewrite doc page requests to their .mdx counterpart.
-  if (
-    prefersMarkdown(request) &&
-    MARKDOWN_PREFIXES.some((prefix) => pathname.startsWith(prefix)) &&
-    !pathname.endsWith('.mdx') &&
-    !pathname.endsWith('.md')
-  ) {
-    const url = request.nextUrl.clone();
-    url.pathname = `${pathname.replace(/\/$/, '')}.mdx`;
-    return NextResponse.rewrite(url);
-  }
 
   // Root redirects
   if (pathname === '/') {
@@ -182,8 +169,7 @@ export default async function middleware(request: NextRequest, event: NextFetchE
   }
 
   // Check if the path doesn't start with any of our known prefixes
-  const knownPrefixes = ['/platform/', '/community/', '/api-reference/', '/framework/', '/guides/'];
-  const startsWithKnownPrefix = knownPrefixes.some((prefix) => pathname.startsWith(prefix));
+  const startsWithKnownPrefix = isDocPage(pathname);
 
   // Skip the catch-all redirect for paths that:
   // 1. Already start with a known prefix
@@ -205,11 +191,25 @@ export default async function middleware(request: NextRequest, event: NextFetchE
     const restOfPath = pathname.startsWith('/') ? pathname.slice(1) : pathname;
 
     // Prevent double redirects - if we're already redirecting to a known path, don't add platform prefix
-    if (!knownPrefixes.some((prefix) => restOfPath.startsWith(prefix.slice(1)))) {
+    if (!MARKDOWN_SECTIONS.some((section) => restOfPath.startsWith(section.slice(1)))) {
       return NextResponse.redirect(new URL(`/platform/${restOfPath}`, request.url), {
         status: 308,
       });
     }
+  }
+
+  // Content negotiation: if an AI agent requests markdown via Accept header,
+  // rewrite doc page requests to their .mdx counterpart.
+  // Runs after all redirects so legacy paths land on the correct page first.
+  if (
+    prefersMarkdown(request) &&
+    isDocPage(pathname) &&
+    !pathname.endsWith('.mdx') &&
+    !pathname.endsWith('.md')
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = `${pathname.replace(/\/$/, '')}.mdx`;
+    return NextResponse.rewrite(url);
   }
 
   return clerkMiddleware(request, event);


### PR DESCRIPTION
Worked on the docs agent friendliness. The fix ensures agents can request for the md format of the docs content 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated endpoints now serve documentation as plain-text and as markdown.
  * URLs for doc sections are mapped to their markdown sources for direct retrieval.

* **Improvements**
  * Content format is automatically selected based on client preferences (Accept header / URL).
  * Copy-to-clipboard fetches the latest markdown directly from the server.
  * Pages emit a markdown alternate link for easier content negotiation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->