### PR TITLE
Update the content for the MCP server docs

### DIFF
--- a/content/docs/platform/additional-resources/mcp.mdx
+++ b/content/docs/platform/additional-resources/mcp.mdx
@@ -6,7 +6,7 @@ icon: Network
 
 import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
-The Novu MCP Server exposes your notification infrastructure as tools that AI assistants can discover and use in real time. 
+The Novu MCP Server exposes Novu's notification infrastructure as tools that AI assistants can discover and use in real time. 
 
 Once connected, you can use natural language to manage notifications in Novu directly from your AI tool.
 For example, you can prompt your AI assistant to:
@@ -157,7 +157,7 @@ Any MCP-compatible tool can connect to the Novu MCP Server. Use the following co
 * **URL**:
   * US: `https://mcp.novu.co/`
   * EU: `https://mcp.novu.co/?region=eu`
-* **Transport**: Streamable HTTP (recommended). Legacy SSE is also supported at `https://mcp.novu.co/sse` but is not recommended.
+* **Transport**: Streamable HTTP (recommended).
 * **Authentication**: Send your API key in the `Authorization` header as `Bearer your-novu-api-key`.
 
 ## Test your setup
@@ -267,8 +267,5 @@ If your setup isn't working, the following sections cover the most common issues
   * For Claude Desktop, ensure Node.js is installed and accessible from your terminal
   * For Claude Code, run `claude mcp list` to confirm the server is registered
   * For Codex, run `/mcp` in the TUI to check server status
-  </Accordion>
-  <Accordion title="Test connectivity directly">
-If you're still stuck, test the connection directly with the MCP Inspector:
   </Accordion>
 </Accordions>

--- a/content/docs/platform/additional-resources/mcp.mdx
+++ b/content/docs/platform/additional-resources/mcp.mdx
@@ -268,7 +268,7 @@ If your setup isn't working, the following sections cover the most common issues
   * For Claude Code, run `claude mcp list` to confirm the server is registered
   * For Codex, run `/mcp` in the TUI to check server status
   </Accordion>
-  <Accordion title=" Test connectivity directly">
+  <Accordion title="Test connectivity directly">
   If you're still stuck, test the connection directly with the MCP Inspector:
  
   ```bash

--- a/content/docs/platform/additional-resources/mcp.mdx
+++ b/content/docs/platform/additional-resources/mcp.mdx
@@ -1,184 +1,257 @@
 ---
-title: Model Context Protocol (MCP)
-description: Enable AI agents to securely access and interact with your Novu notification infrastructure using the Model Context Protocol (MCP).
+title: MCP Server
+description: Connect your AI tools to Novu using MCP and manage notifications using natural language.
 icon: Network
 ---
 
-import { Tab, Tabs } from 'fumadocs-ui/components/tabs';
+import { Accordion, Accordions } from 'fumadocs-ui/components/accordion';
 
-## What is Model Context Protocol?
+The Novu MCP Server exposes your notification infrastructure as tools that AI assistants can discover and use in real time. 
 
-MCP is a protocol that enables AI tools and applications to connect with Novu's data and services in a secure, standardized way. It provides a structured method for AI models to:
+Once connected, you can use natural language to manage notifications in Novu directly from your AI tool.
+For example, you can prompt your AI assistant to:
 
-* Find and retrieve Novu data (subscribers, workflows, notifications, etc.)
-* Access specific tools and functionality provided by Novu
-* Maintain context about your Novu workspace when working with AI assistants
-* Trigger workflows and manage notification preferences
+* Trigger workflows for specific subscribers  
+* Search and inspect subscriber data  
+* Update subscriber notification preferences  
+* Debug failed notifications and delivery issues  
+* Analyze notification activity and logs  
+* Create and manage workflows
 
-## How MCP Works
+## How Novu MCP works
 
-Novu hosts a remote MCP server that handles requests from AI tools and provides access to Novu data through a secure interface.
+The Novu MCP Server exposes your notification system as a set of tools.
 
-**Connection URLs:**
+When your AI assistant connects:
+1. It authenticates using your API key.
+2. It discovers available tools.
+3. It executes actions based on your prompts.
 
-* **US Region**: `https://mcp.novu.co/` (Streamable HTTP - Recommended)
-* **EU Region**: `https://mcp.novu.co/?region=eu` (Streamable HTTP - Recommended)
-* **Legacy SSE**: `https://mcp.novu.co/sse` (also supported in both regions but not recommended)
+Instead of calling APIs directly, the AI translates your request into tool calls and executes them against your Novu environment.
 
-When an AI tool connects to Novu's MCP server, authentication verifies the user's API key and permissions, then the tool can access relevant Novu data and functionality.
+## Prerequisite
+To use the Novu MCP Server, you'll need:
 
-## Available Tools
+* A [Novu API key](https://dashboard.novu.co/settings/api-keys)
+* An MCP-compatible AI tool (Cursor, Codex, Claude Code, Claude Desktop)
 
-The Novu MCP Server provides **13 tools** for interacting with the Novu API:
-
-### Core Operations
-- **get_api_key_status** - Check API key status and region configuration
-- **get_environments** - List development and production environments
-
-### Workflow Management
-- **get_workflows** - List all workflows with names and identifiers
-- **get_workflow** - Get detailed workflow configuration and payload structure
-- **trigger_workflow** - Execute workflows with custom data for specific subscribers
-- **create_workflow** - Create new workflows with comprehensive configuration including steps, channels, and validation
-- **update_workflow** - Update existing workflows with modified steps, preferences, and configuration
-- **delete_workflow** - Delete workflows by their unique identifier (irreversible action)
-
-### Subscriber Management
-- **find_subscribers** - Search subscribers by email, phone, name, or ID
-
-### Notification Analytics
-- **get_notifications** - Get notifications with filtering by channels, workflows, dates
-- **get_notification** - Get specific notification details with execution logs
-
-### Preference Management
-- **get_subscriber_preferences** - Get subscriber notification preferences for all channels
-- **update_subscriber_preferences** - Update subscriber channel preferences globally or per workflow
+<Callout>Some tools like Claude Desktop require Node.js to run MCP servers locally.</Callout>
 
 ## Setup
 
-### Prerequisites
+Follow these steps to setup the Novu MCP server:
 
-- Novu API key from [dashboard.novu.co](https://dashboard.novu.co/settings/api-keys)
-- MCP-compatible AI assistant (Claude Desktop, Claude.ai, Cursor, Windsurf)
-- Node.js installed (for Claude Desktop users)
+### 1. Get your secret key
 
-### Authentication
+Your secret key authenticates your AI tool with Novu. To retrieve it:
+1. Go to the [Novu Dashboard](https://dashboard.novu.co)
+2. Navigate to **API Keys**
+3. Under **Secret Keys**, copy your secret key
 
-1. Get your API key from the [Novu Dashboard](https://dashboard.novu.co/settings/api-keys)
-2. Identify your region from the dashboard URL:
-   - `dashboard.novu.co` = **US region**
-   - `eu.dashboard.novu.co` = **EU region**
+### 2. Identify your region
 
-### Configuration
+Your region determines which URL your AI tool connects to. To identify it, check your dashboard URL:
 
-<Tabs items={['Claude Desktop', 'Claude.ai', 'Cursor', 'Other Tools']}>
-<Tab value="Claude Desktop">
+| Dashboard URL | Region | MCP URL |
+|---|---|---|
+| `dashboard.novu.co` | US | `https://mcp.novu.co/` |
+| `eu.dashboard.novu.co` | EU | `https://mcp.novu.co/?region=eu` |
+ 
+The MCP URL above is what you'll use in the next step when configuring your tool.
 
-**File Location:**
-- **macOS**: `~/Library/Application\ Support/Claude/claude_desktop_config.json`
-- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+### 3. Configure your tool
+ 
+The following sections cover setup for the most common MCP-compatible AI tools. Before you start, keep two things in mind as you work through the examples:
+ 
+- **Replace the API key.** Each example uses `your-novu-api-key` as a placeholder. Replace it with the API key you copied earlier.
+- **Use the correct URL for your region.** The examples use the US endpoint (`https://mcp.novu.co/`). If you're on the EU region, replace it with `https://mcp.novu.co/?region=eu`.
+#### Cursor
+ 
+Cursor supports remote MCP servers through its built-in settings UI, which writes to an `mcp.json` file. To add the Novu MCP Server:
+ 
+1. Open **Cursor Settings**, and select **Tools & Integrations**.
+2. Under **MCP Tools**, select **New MCP Server**. This opens your `mcp.json` file.
+3. Add the following to the `mcpServers` object:
+   ```json
+   {
+     "mcpServers": {
+       "novu": {
+         "url": "https://mcp.novu.co/",
+         "headers": {
+           "Authorization": "Bearer your-novu-api-key"
+         }
+       }
+     }
+   }
+   ```
+ 
+4. Save the file. Cursor detects the new server automatically.
+#### Codex
+ 
+Codex reads MCP configuration from `~/.codex/config.toml`. The CLI and IDE extension share this file, so you only need to configure the server once. To add the Novu MCP Server:
+ 
+1. Export your API key as an environment variable in your shell:
+   ```bash
+   export NOVU_API_KEY="your-novu-api-key"
+   ```
+ 
+2. Open `~/.codex/config.toml` in your preferred text editor and add the following:
+   ```toml
+   [mcp_servers.novu]
+   url = "https://mcp.novu.co/"
+   bearer_token_env_var = "NOVU_API_KEY"
+   ```
+ 
+3. Save the file and restart Codex.
+To verify the connection, run `/mcp` inside the Codex TUI. You should see `novu` listed as a connected server.
+ 
+#### Claude Code
+ 
+Claude Code manages MCP servers through its `claude mcp` command. To add the Novu MCP Server:
+ 
+1. In your terminal, run:
+   ```bash
+   claude mcp add --transport http novu https://mcp.novu.co/ \
+     --header "Authorization: Bearer your-novu-api-key"
+   ```
+ 
+2. To make Novu available across all your projects instead of just the current one, add the `--scope user` flag:
+   ```bash
+   claude mcp add --scope user --transport http novu https://mcp.novu.co/ \
+     --header "Authorization: Bearer your-novu-api-key"
+   ```
+ 
+3. Verify the connection by running `claude mcp list`. You can also run `/mcp` inside Claude Code to check server status.
+#### Claude Desktop
+ 
+Claude Desktop connects to remote MCP servers through a local proxy (`mcp-remote`), which requires Node.js 18 or higher. To add the Novu MCP Server:
+ 
+1. Open Claude Desktop, go to **Settings**, and find the **Developer** section.
+2. Select **Edit Config**. This opens your `claude_desktop_config.json` file.
+3. Add the following to the `mcpServers` object (or create the object if it doesn't exist):
+   ```json
+   {
+     "mcpServers": {
+       "novu": {
+         "command": "npx",
+         "args": [
+           "mcp-remote",
+           "https://mcp.novu.co/",
+           "--header",
+           "Authorization:Bearer ${NOVU_API_KEY}"
+         ],
+         "env": {
+           "NOVU_API_KEY": "your-novu-api-key"
+         }
+       }
+     }
+   }
+   ```
+ 
+4. Save the file and restart Claude Desktop.
 
-```json
-{
-  "mcpServers": {
-    "novu": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.novu.co/",
-        "--header",
-        "Authorization:Bearer ${NOVU_API_KEY}"
-      ],
-      "env": {
-        "NOVU_API_KEY": "your-novu-api-key-here"
-      }
-    }
-  }
-}
-```
+#### Other tools
+ 
+Any MCP-compatible tool can connect to the Novu MCP Server. Use the following connection details:
+ 
+* **URL**:
+  * US: `https://mcp.novu.co/`
+  * EU: `https://mcp.novu.co/?region=eu`
+* **Transport**: Streamable HTTP (recommended). Legacy SSE is also supported at `https://mcp.novu.co/sse` but is not recommended.
+* **Authentication**: Send your API key in the `Authorization` header as `Bearer your-novu-api-key`.
 
-For **EU region**:
-```json
-{
-  "mcpServers": {
-    "novu": {
-      "command": "npx",
-      "args": [
-        "mcp-remote",
-        "https://mcp.novu.co/?region=eu",
-        "--header",
-        "Authorization:Bearer ${NOVU_API_KEY}"
-      ],
-      "env": {
-        "NOVU_API_KEY": "your-novu-api-key-here"
-      }
-    }
-  }
-}
-```
-
-</Tab>
-<Tab value="Claude.ai">
-
-Navigate to **Settings** → **Integrations** → **+ Add Integration**:
-
-- **Name**: `Novu`
-- **URL**: `https://mcp.novu.co/` (US) or `https://mcp.novu.co/?region=eu` (EU)
-- **Headers**: `Authorization: Bearer your-novu-api-key`
-
-</Tab>
-<Tab value="Cursor">
-
-In **Settings** → **Extensions** → **MCP Servers**:
-
-```json
-{
-  "mcpServers": {
-    "novu": {
-      "url": "https://mcp.novu.co/",
-      "headers": {
-        "Authorization": "Bearer your-novu-api-key"
-      }
-    }
-  }
-}
-```
-
-</Tab>
-<Tab value="Other Tools">
-
-**Standard MCP Configuration:**
-- **URL**: `https://mcp.novu.co/` (US) or `https://mcp.novu.co/?region=eu` (EU)
-- **Authentication**: Header `Authorization: Bearer your-novu-api-key`
-- **Protocol**: Streamable HTTP (MCP over HTTP)
-
-</Tab>
-</Tabs>
-
-## Testing Your Setup
-
-After configuration, test with these commands:
-
-### Basic Operations
+## Test your setup
+ 
+To verify that the connection works, try any of the prompts below in your AI assistant:
+ 
 ```
 "Check my Novu API key status"
-"Show me all my notification workflows"  
+"Show me all my notification workflows"
 "Find subscriber with email user@example.com"
 ```
+ 
+If you get results back, the Novu MCP Server is connected and working.
+
+## Available tools
+
+The Novu MCP server currently provides **13 tools** for interacting with your Novu environment:
+ 
+### Core operations
+ 
+These tools let you inspect your account configuration:
+ 
+| Tool | Description |
+|---|---|
+| `get_api_key_status` | Check API key status and region configuration |
+| `get_environments` | List development and production environments |
+ 
+### Workflow management
+ 
+These tools let you create, inspect, and manage notification workflows:
+ 
+| Tool | Description |
+|---|---|
+| `get_workflows` | List all workflows with names and identifiers |
+| `get_workflow` | Get detailed workflow configuration and payload structure |
+| `trigger_workflow` | Execute workflows with custom data for specific subscribers |
+| `create_workflow` | Create new workflows with steps, channels, and validation |
+| `update_workflow` | Update existing workflows with modified steps, preferences, and configuration |
+| `delete_workflow` | Delete workflows by their unique identifier (irreversible) |
+ 
+### Subscriber management
+ 
+This tool lets you search your subscriber base:
+ 
+| Tool | Description |
+|---|---|
+| `find_subscribers` | Search subscribers by email, phone, name, or ID |
+ 
+### Notification analytics
+ 
+These tools let you inspect delivery and execution data:
+ 
+| Tool | Description |
+|---|---|
+| `get_notifications` | Get notifications with filtering by channels, workflows, and dates |
+| `get_notification` | Get specific notification details with execution logs |
+ 
+### Preference management
+ 
+These tools let you view and update how subscribers receive notifications:
+ 
+| Tool | Description |
+|---|---|
+| `get_subscriber_preferences` | Get subscriber notification preferences for all channels |
+| `update_subscriber_preferences` | Update subscriber channel preferences globally or per workflow |
+ 
 
 ## Troubleshooting
 
-**Common Issues:**
-- **Authentication errors**: Verify API key is valid and has no extra spaces
-- **Empty results**: Check you're using the correct region (US/EU)
-- **Connection issues**: Restart your AI assistant after configuration changes
+If your setup isn't working, the following sections cover the most common issues.
 
-**Test connectivity:**
-```bash
-npx @modelcontextprotocol/inspector
-```
-Connect with Transport Type: Streamable HTTP, URL: `https://mcp.novu.co/`, Headers: `Authorization: Bearer your-api-key`
+<Accordions type="single">
+  <Accordion title="Authentication errors">
+  * Verify your API key is valid and has no extra spaces or line breaks
+  * Check that you're using the correct header format: `Authorization: Bearer your-api-key`
+  </Accordion>
 
----
+  <Accordion title="Empty results">
+  Confirm you're using the correct region. If your dashboard is at `eu.dashboard.novu.co`, you need the EU endpoint
+  </Accordion>
 
-For additional help, check the [Novu documentation](https://docs.novu.co) or join our [Discord community](https://discord.novu.co). 
+  <Accordion title="Connection issues">
+  * Restart your AI assistant after making configuration changes
+  * For Claude Desktop, ensure Node.js is installed and accessible from your terminal
+  * For Claude Code, run `claude mcp list` to confirm the server is registered
+  * For Codex, run `/mcp` in the TUI to check server status
+  </Accordion>
+  <Accordion title=" Test connectivity directly">
+  If you're still stuck, test the connection directly with the MCP Inspector:
+ 
+  ```bash
+  npx @modelcontextprotocol/inspector
+  ```
+
+  Connect with Transport Type `Streamable HTTP`, URL `https://mcp.novu.co/`, and header `Authorization: Bearer your-api-key`. If the inspector connects successfully, the issue is likely in your AI tool's configuration rather than the server itself.
+  </Accordion>
+</Accordions>

--- a/content/docs/platform/additional-resources/mcp.mdx
+++ b/content/docs/platform/additional-resources/mcp.mdx
@@ -269,12 +269,6 @@ If your setup isn't working, the following sections cover the most common issues
   * For Codex, run `/mcp` in the TUI to check server status
   </Accordion>
   <Accordion title="Test connectivity directly">
-  If you're still stuck, test the connection directly with the MCP Inspector:
- 
-  ```bash
-  npx @modelcontextprotocol/inspector
-  ```
-
-  Connect with Transport Type `Streamable HTTP`, URL `https://mcp.novu.co/`, and header `Authorization: Bearer your-api-key`. If the inspector connects successfully, the issue is likely in your AI tool's configuration rather than the server itself.
+If you're still stuck, test the connection directly with the MCP Inspector:
   </Accordion>
 </Accordions>

--- a/content/docs/platform/additional-resources/mcp.mdx
+++ b/content/docs/platform/additional-resources/mcp.mdx
@@ -138,7 +138,7 @@ Claude Desktop connects to remote MCP servers through a local proxy (`mcp-remote
            "mcp-remote",
            "https://mcp.novu.co/",
            "--header",
-           "Authorization:Bearer ${NOVU_API_KEY}"
+           "Authorization: Bearer ${NOVU_API_KEY}"
          ],
          "env": {
            "NOVU_API_KEY": "your-novu-api-key"

--- a/content/docs/platform/additional-resources/mcp.mdx
+++ b/content/docs/platform/additional-resources/mcp.mdx
@@ -185,45 +185,68 @@ These tools let you inspect your account configuration:
 | `get_api_key_status` | Check API key status and region configuration |
 | `get_environments` | List development and production environments |
  
-### Workflow management
- 
-These tools let you create, inspect, and manage notification workflows:
- 
-| Tool | Description |
-|---|---|
-| `get_workflows` | List all workflows with names and identifiers |
-| `get_workflow` | Get detailed workflow configuration and payload structure |
-| `trigger_workflow` | Execute workflows with custom data for specific subscribers |
-| `create_workflow` | Create new workflows with steps, channels, and validation |
-| `update_workflow` | Update existing workflows with modified steps, preferences, and configuration |
-| `delete_workflow` | Delete workflows by their unique identifier (irreversible) |
- 
 ### Subscriber management
  
-This tool lets you search your subscriber base:
+These tools let you create, inspect, and manage your subscribers:
  
 | Tool | Description |
 |---|---|
-| `find_subscribers` | Search subscribers by email, phone, name, or ID |
+| `create_subscriber` | Create a new subscriber with attributes like name, email, phone, and custom data |
+| `get_subscriber` | Retrieve a single subscriber by their `subscriberId` |
+| `update_subscriber` | Update an existing subscriber's attributes |
+| `delete_subscriber` | Delete a subscriber by their `subscriberId` |
+| `find_subscribers` | Search for subscribers using various query parameters |
  
-### Notification analytics
- 
-These tools let you inspect delivery and execution data:
- 
-| Tool | Description |
-|---|---|
-| `get_notifications` | Get notifications with filtering by channels, workflows, and dates |
-| `get_notification` | Get specific notification details with execution logs |
- 
-### Preference management
+### Preferences
  
 These tools let you view and update how subscribers receive notifications:
  
 | Tool | Description |
 |---|---|
 | `get_subscriber_preferences` | Get subscriber notification preferences for all channels |
-| `update_subscriber_preferences` | Update subscriber channel preferences globally or per workflow |
+| `update_subscriber_preferences` | Update subscriber notification preferences for specific channels |
  
+### Workflow management
+ 
+These tools let you create, inspect, and manage notification workflows:
+ 
+| Tool | Description |
+|---|---|
+| `create_workflow` | Create a new workflow with comprehensive configuration including steps |
+| `get_workflow` | Get detailed information about a specific workflow |
+| `get_workflows` | Get all available workflows |
+| `update_workflow` | Update an existing workflow |
+| `delete_workflow` | Delete an existing workflow by its unique identifier |
+ 
+### Triggering and events
+ 
+These tools let you execute workflows and manage pending notifications:
+ 
+| Tool | Description |
+|---|---|
+| `trigger_workflow` | Trigger a workflow to send notifications to a subscriber |
+| `bulk_trigger_workflow` | Trigger multiple workflows in a single API call |
+| `cancel_triggered_event` | Cancel a pending triggered event |
+ 
+### Notifications
+ 
+These tools let you inspect delivery and execution data:
+ 
+| Tool | Description |
+|---|---|
+| `get_notification` | Get a specific notification by ID with detailed execution logs |
+| `get_notifications` | Get notifications and events with advanced filtering options |
+ 
+### Integrations
+ 
+These tools let you manage the channel providers connected to your Novu account:
+ 
+| Tool | Description |
+|---|---|
+| `get_integrations` | List all channel integrations (email, SMS, push, chat, in-app) |
+| `get_active_integrations` | List only the active integrations |
+| `delete_integration` | Delete an integration by its `integrationId` |
+| `set_primary_integration` | Mark an integration as the primary for its channel |
 
 ## Troubleshooting
 


### PR DESCRIPTION
Update the content for the MCP documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reframed MCP content to "MCP Server" with reorganized sections for clearer flow.
  * Converted setup to a step-by-step guide with per-tool configuration examples for Cursor, Codex, Claude Code, and Claude Desktop.
  * Updated prerequisites to call out compatibility and Node.js requirement for local Claude Desktop.
  * Replaced tester commands with example assistant prompts and added an accordion-based troubleshooting UI with tool-specific checks.
  * Presented available tools as categorized tables for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->