### PR TITLE
chore(deps): set pnpm minimumReleaseAge to 3 days (fixes DOC-315)

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -14,9 +14,9 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 10
           run_install: false
 
       - name: Setup Node.js

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,1 @@
+minimumReleaseAge: 4320


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds a `pnpm-workspace.yaml` with `minimumReleaseAge: 4320` (3 days, in minutes), and bumps CI to pnpm v10 so the setting is actually honored there.

```yaml
minimumReleaseAge: 4320
```

## Why

`minimumReleaseAge` ([pnpm docs](https://pnpm.io/settings#minimumreleaseage)) tells pnpm to refuse to install any package version (direct or transitive) that has been published to the registry less than the specified number of minutes ago.

Most malicious package releases (typo-squats, compromised maintainer accounts, supply-chain attacks like the recent `chalk`/`debug`/`shai-hulud` incidents) are detected and yanked from the npm registry within hours. A 3-day delay means installs in this repo will not pull in such releases during the high-risk window immediately after publication.

This is a "free" hardening — it requires no code changes and only causes friction when intentionally upgrading to a brand-new release.

## Why a separate `pnpm-workspace.yaml` instead of `package.json`

pnpm only reads `minimumReleaseAge` from `pnpm-workspace.yaml` or `.npmrc`. It is **not** honored when placed under the `pnpm` field of `package.json` (only a fixed allow-list of settings like `overrides`, `packageExtensions`, `patchedDependencies`, etc. are read from there). Verified locally — see test notes below.

## CI bump

The PR checks workflow was previously pinned to pnpm v9, which:

1. Doesn't support `minimumReleaseAge` at all (added in v10.16.0), so the setting would have been silently ignored on CI installs.
2. Errors on a `pnpm-workspace.yaml` that omits the `packages` field (`ERR_PNPM_NO_PKG_MANIFEST … packages field missing or empty`).

Bumped `pnpm/action-setup` from `v2` → `v4` and `version: 9` → `version: 10`, which matches the local development version (`pnpm 10.30.3`). pnpm v10+ treats `pnpm-workspace.yaml` as config-only when `packages` is omitted.

## Notes

- `minimumReleaseAge` was added in pnpm `v10.16.0`; the repo (and now CI) uses pnpm `v10.x`, so it is supported.
- pnpm v10 default for unconfigured `minimumReleaseAgeStrict` is "on when the user explicitly configures `minimumReleaseAge`" — so if a transitive dep has no version older than 3 days that satisfies its range, install will fail with a clear error rather than silently falling back. That is the desired behavior.

## Testing

1. Local: ran `pnpm install` with the new config — succeeds (lockfile already satisfies the constraint, since all currently locked versions are well over 3 days old).
2. Local: to confirm pnpm actually reads the setting from `pnpm-workspace.yaml`, temporarily replaced it with `minimumReleaseAge: 525600000` + `minimumReleaseAgeStrict: true` and ran `pnpm add -D is-odd@latest`. pnpm correctly rejected with `ERR_PNPM_NO_MATCHING_VERSION` (no version is younger than ~1000 years). Restored the file afterwards.
3. CI: `Build and Lint` workflow passes after the pnpm-version bump (previous failure was the pnpm v9 incompatibility described above).

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/D0919LNRWE7/p1778560019839269?thread_ts=1778560019.839269&cid=D0919LNRWE7)

<div><a href="https://cursor.com/agents/bc-20442154-230a-5f9d-80b2-04114b6dc9a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20442154-230a-5f9d-80b2-04114b6dc9a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

