### PR TITLE
fix(DOC-329): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -11,16 +11,16 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
           run_install: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -35,7 +35,7 @@ jobs:
           pnpm run format:check
 
       - name: Vale prose lint
-        uses: vale-cli/vale-action@v2.1.1
+        uses: vale-cli/vale-action@d89dee975228ae261d22c15adcd03578634d429c # v2.1.1
         with:
           version: 3.9.1
           files: content


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pins all GitHub Actions used in CI workflows to immutable commit SHAs instead of floating version tags. Each pin includes an inline version comment for easier future updates.

## Changes

- `actions/checkout@v4` → `34e114876b0b11c390a56381ad16ebd13914f8d5`
- `pnpm/action-setup@v4` → `b906affcce14559ad1aafd4ab0e942779e9f58b1`
- `actions/setup-node@v4` → `49933ea5288caeca8642d1e84afbd3f7d6820020`
- `vale-cli/vale-action@v2.1.1` → `d89dee975228ae261d22c15adcd03578634d429c`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://novu.slack.com/archives/C0ALBUKK3FA/p1779257688487139?thread_ts=1779257688.487139&cid=C0ALBUKK3FA)

<div><a href="https://cursor.com/agents/bc-cb7c115a-fe8d-51bc-a5ce-660f4ed70ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cb7c115a-fe8d-51bc-a5ce-660f4ed70ec2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal continuous integration configurations for enhanced security practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/novuhq/docs/pull/1101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->