### PR TITLE
docs(platform): Document new webhook vendor connectors fixes DOC-343

### DIFF
--- a/content/docs/platform/developer/webhooks/connectors.mdx
+++ b/content/docs/platform/developer/webhooks/connectors.mdx
@@ -1,0 +1,157 @@
+---
+title: 'Webhook connectors'
+pageTitle: 'Novu webhook connectors'
+description: 'Send Novu webhook events directly to data warehouses, analytics databases, and AWS messaging services.'
+---
+
+In addition to standard HTTP webhook endpoints, Novu supports webhook connectors that deliver events directly to third-party services. These connectors are powered by [Svix](https://www.svix.com/) and let you route Novu events to data warehouses, analytics databases, and AWS messaging services without building a custom receiver.
+
+<Callout>This webhook feature is only available on the <a href="https://novu.co/pricing" target="_blank" rel="noopener noreferrer">Team and Enterprise plans</a>.</Callout>
+
+## How to add a connector endpoint
+
+1. Go to the **[Webhooks](https://dashboard.novu.co/webhooks)** page in the Novu dashboard.
+2. Select the **Endpoints** tab.
+3. Click **Add Endpoint**.
+4. Search for or select the connector you want to use from the integrations list.
+  ![Webhook integrations list](/images/developer-tools/webhook-integrations.png)
+5. Enter a **Description** to identify this endpoint.
+6. Configure the connector-specific settings described in the sections below.
+7. Select the [event types](/platform/developer/webhooks/event-types) you want this endpoint to subscribe to.
+8. Click **Create**.
+
+After the endpoint is created, Novu delivers matching events to your configured destination. You can monitor delivery attempts, retry failed messages, and test the endpoint from the dashboard.
+
+## Available connectors
+
+Novu supports the following webhook connectors:
+
+| Connector | Description |
+| --- | --- |
+| [ClickHouse](#clickhouse) | Store events in a ClickHouse table. |
+| [Snowflake](#snowflake) | Store events in a Snowflake table. |
+| [Amazon Redshift](#amazon-redshift) | Store events in an Amazon Redshift table. |
+| [Amazon SQS](#amazon-sqs) | Send events to an Amazon SQS queue. |
+| [Amazon SNS](#amazon-sns) | Send events to an Amazon SNS topic. |
+
+## ClickHouse
+
+The ClickHouse connector stores Novu webhook events directly in a ClickHouse table. Use it when you want to analyze notification events in ClickHouse without building a custom ingestion pipeline.
+
+### Configuration
+
+| Field | Required | Description |
+| --- | --- | --- |
+| URL | Yes | The ClickHouse server URL (for example, `https://clickhouse.example.com:8443`). |
+| Username | Yes | The username used to authenticate with ClickHouse. |
+| Password | Yes | The password for the ClickHouse user. |
+| Table name | Yes | The name of the table where events are stored. |
+| Database | No | The ClickHouse database name. If omitted, the default database is used. |
+
+### Setup
+
+1. Create a ClickHouse table to receive webhook events.
+2. Ensure the configured user has permission to insert rows into the target table.
+3. In the Novu dashboard, select **ClickHouse** when adding a webhook endpoint and fill in the configuration fields.
+4. Select the event types you want to store and create the endpoint.
+
+## Snowflake
+
+The Snowflake connector stores Novu webhook events directly in a Snowflake table. Use it when you want notification data available in your Snowflake data warehouse for reporting, analytics, or downstream pipelines.
+
+### Configuration
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Account identifier | Yes | Your Snowflake account identifier. |
+| User ID | Yes | The Snowflake user used to authenticate. |
+| Private key | Yes | The private key for key-pair authentication. |
+| Database name | No | The Snowflake database where events are stored. |
+| Schema name | No | The schema containing the target table. |
+| Table name | No | The table where events are stored. |
+
+### Setup
+
+1. Create a Snowflake table to receive webhook events.
+2. Configure a Snowflake user with key-pair authentication and insert permissions on the target table.
+3. In the Novu dashboard, select **Snowflake** when adding a webhook endpoint and fill in the configuration fields.
+4. Select the event types you want to store and create the endpoint.
+
+## Amazon Redshift
+
+The Amazon Redshift connector stores Novu webhook events directly in a Redshift table. Use it when you want notification events available in your Redshift data warehouse for analytics and reporting.
+
+### Configuration
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Region | Yes | The AWS region where your Redshift cluster or workgroup is located. |
+| Access key ID | Yes | The AWS access key ID with permission to write to Redshift. |
+| Secret access key | Yes | The AWS secret access key for the IAM user. |
+| Cluster identifier | No | The Redshift cluster identifier. Required for provisioned clusters. |
+| Workgroup name | No | The Redshift Serverless workgroup name. Required for serverless deployments. |
+| Database user | No | The database user for provisioned clusters. |
+| Database name | No | The Redshift database where events are stored. |
+| Schema name | No | The schema containing the target table. |
+| Table name | No | The table where events are stored. |
+
+<Callout type="info">For provisioned Redshift clusters, set **Cluster identifier** and **Database user**. For Redshift Serverless, set **Workgroup name** instead.</Callout>
+
+### Setup
+
+1. Create a Redshift table to receive webhook events.
+2. Create an IAM user with the permissions required to write data to Redshift.
+3. In the Novu dashboard, select **Redshift** when adding a webhook endpoint and fill in the configuration fields.
+4. Select the event types you want to store and create the endpoint.
+
+## Amazon SQS
+
+The Amazon SQS connector sends Novu webhook events to an Amazon SQS queue. Use it when you want to process notification events asynchronously through your existing AWS messaging infrastructure.
+
+### Configuration
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Queue URL | Yes | The URL of the target SQS queue. |
+| Region | Yes | The AWS region where the queue is located. |
+| Access key ID | Yes | The AWS access key ID with permission to send messages to the queue. |
+| Secret access key | Yes | The AWS secret access key for the IAM user. |
+| Endpoint URL | No | A custom endpoint URL. Use this when connecting to LocalStack or other SQS-compatible services. |
+
+### Setup
+
+1. Create an SQS queue in your AWS account.
+2. Create an IAM user with `sqs:SendMessage` permission on the target queue.
+3. In the Novu dashboard, select **SQS** when adding a webhook endpoint and fill in the configuration fields.
+4. Select the event types you want to deliver and create the endpoint.
+
+## Amazon SNS
+
+The Amazon SNS connector publishes Novu webhook events to an Amazon SNS topic. Use it when you want to fan out notification events to multiple subscribers through SNS.
+
+### Configuration
+
+| Field | Required | Description |
+| --- | --- | --- |
+| Topic ARN | Yes | The ARN of the target SNS topic. |
+| Region | Yes | The AWS region where the topic is located. |
+| Access key ID | Yes | The AWS access key ID with permission to publish to the topic. |
+| Secret access key | Yes | The AWS secret access key for the IAM user. |
+| Endpoint URL | No | A custom endpoint URL. Use this when connecting to LocalStack or other SNS-compatible services. |
+
+### Setup
+
+1. Create an SNS topic in your AWS account.
+2. Create an IAM user with `sns:Publish` permission on the target topic.
+3. In the Novu dashboard, select **SNS** when adding a webhook endpoint and fill in the configuration fields.
+4. Select the event types you want to publish and create the endpoint.
+
+## Monitoring and troubleshooting
+
+Connector endpoints support the same delivery monitoring, retry, and recovery features as standard webhook endpoints. From the endpoint details page in the Novu dashboard, you can:
+
+- View delivery attempts and failure reasons in the **Logs** tab.
+- Resend individual failed events.
+- Recover or replay failed messages from a selected time window.
+
+If deliveries fail consistently, verify that your connector credentials are valid and that the destination service (database, queue, or topic) is accessible from Novu's webhook infrastructure.

--- a/content/docs/platform/developer/webhooks/connectors.mdx
+++ b/content/docs/platform/developer/webhooks/connectors.mdx
@@ -4,7 +4,7 @@ pageTitle: 'Novu webhook connectors'
 description: 'Send Novu webhook events directly to data warehouses, analytics databases, and AWS messaging services.'
 ---
 
-In addition to standard HTTP webhook endpoints, Novu supports webhook connectors that deliver events directly to third-party services. These connectors are powered by [Svix](https://www.svix.com/) and let you route Novu events to data warehouses, analytics databases, and AWS messaging services without building a custom receiver.
+In addition to standard HTTP webhook endpoints, Novu supports webhook connectors that deliver events directly to third-party services. Use them to route Novu events to data warehouses, analytics databases, and AWS messaging services without building a custom receiver.
 
 <Callout>This webhook feature is only available on the <a href="https://novu.co/pricing" target="_blank" rel="noopener noreferrer">Team and Enterprise plans</a>.</Callout>
 

--- a/content/docs/platform/developer/webhooks/connectors.mdx
+++ b/content/docs/platform/developer/webhooks/connectors.mdx
@@ -2,11 +2,14 @@
 title: 'Webhook connectors'
 pageTitle: 'Novu webhook connectors'
 description: 'Send Novu webhook events directly to data warehouses, analytics databases, and AWS messaging services.'
+icon: 'Plug'
 ---
 
 In addition to standard HTTP webhook endpoints, Novu supports webhook connectors that deliver events directly to third-party services. Use them to route Novu events to data warehouses, analytics databases, and AWS messaging services without building a custom receiver.
 
-<Callout>This webhook feature is only available on the <a href="https://novu.co/pricing" target="_blank" rel="noopener noreferrer">Team and Enterprise plans</a>.</Callout>
+Novu webhook delivery is powered by [Svix](https://docs.svix.com/introduction). Connector endpoints use Svix [transformations](https://docs.svix.com/transformations) to shape each event before it is written to your destination.
+
+<Callout>Outbound webhooks feature is only available in the <a href="https://novu.co/pricing" target="_blank" rel="noopener noreferrer">Team and Enterprise plans</a>.</Callout>
 
 ## How to add a connector endpoint
 
@@ -16,9 +19,12 @@ In addition to standard HTTP webhook endpoints, Novu supports webhook connectors
 4. Search for or select the connector you want to use from the integrations list.
   ![Webhook integrations list](/images/developer-tools/webhook-integrations.png)
 5. Enter a **Description** to identify this endpoint.
-6. Configure the connector-specific settings described in the sections below.
-7. Select the [event types](/platform/developer/webhooks/event-types) you want this endpoint to subscribe to.
-8. Click **Create**.
+6. Configure the connector-specific connection settings described in the sections below.
+7. For **data warehouse connectors** (ClickHouse, Snowflake, Redshift): define the **table schema** and write a **transformation** that maps Novu webhook payloads to rows matching that schema. See [Data warehouse connectors](#data-warehouse-connectors).
+8. For **message connectors** (Amazon SQS, Amazon SNS): review and customize the **transformation** that shapes the message body sent to the queue or topic. See [Message connectors](#message-connectors).
+9. Select the [event types](/platform/developer/webhooks/event-types) you want this endpoint to subscribe to.
+10. Click **Create**.
+11. Open the endpoint, go to the **Testing** tab, and **Send Example** for each subscribed event type. Confirm delivery succeeds in **Logs**, then verify the row or message appears in your destination.
 
 After the endpoint is created, Novu delivers matching events to your configured destination. You can monitor delivery attempts, retry failed messages, and test the endpoint from the dashboard.
 
@@ -26,13 +32,98 @@ After the endpoint is created, Novu delivers matching events to your configured 
 
 Novu supports the following webhook connectors:
 
-| Connector | Description |
+| Connector | Type | Description |
+| --- | --- | --- |
+| [ClickHouse](#clickhouse) | Data warehouse | Store events in a ClickHouse table. |
+| [Snowflake](#snowflake) | Data warehouse | Store events in a Snowflake table. |
+| [Amazon Redshift](#amazon-redshift) | Data warehouse | Store events in an Amazon Redshift table. |
+| [Amazon SQS](#amazon-sqs) | Message | Send events to an Amazon SQS queue. |
+| [Amazon SNS](#amazon-sns) | Message | Send events to an Amazon SNS topic. |
+
+Additional warehouse connectors (such as BigQuery) may appear in the dashboard. They follow the same **table schema + transformation** pattern described below.
+
+## Transformations
+
+Every connector endpoint runs a JavaScript **transformation** before delivery. The transformation converts the raw Novu webhook into the format your destination expects.
+
+In the Novu dashboard, configure the transformation when creating or editing a connector endpoint. Each connector type ships with a default template—use it as your starting point.
+
+### How to write a transformation
+
+Svix expects a function named `handler`. For connector endpoints, the handler receives a `webhook` object with:
+
+| Property | Description |
 | --- | --- |
-| [ClickHouse](#clickhouse) | Store events in a ClickHouse table. |
-| [Snowflake](#snowflake) | Store events in a Snowflake table. |
-| [Amazon Redshift](#amazon-redshift) | Store events in an Amazon Redshift table. |
-| [Amazon SQS](#amazon-sqs) | Send events to an Amazon SQS queue. |
-| [Amazon SNS](#amazon-sns) | Send events to an Amazon SNS topic. |
+| `webhook.eventType` | The Novu event type (for example, `message.sent`). |
+| `webhook.payload` | The webhook JSON body. Shape depends on the event type—see [event types](/platform/developer/webhooks/event-types). |
+| `webhook.method` | HTTP method. Usually `"POST"`. |
+| `webhook.url` | Destination URL. Generally leave unchanged for connectors. |
+| `webhook.cancel` | Set to `true` to skip delivery for a given event. Defaults to `false`. |
+
+The handler must return the `webhook` object after modifying `webhook.payload` (and optionally other allowed properties). Test your code in the dashboard against a sample payload before going live.
+
+<Callout type="info">Handle every [event type](/platform/developer/webhooks/event-types) your endpoint subscribes to. Use `switch (webhook.eventType)` or equivalent logic so each event maps to a valid destination record.</Callout>
+
+## Data warehouse connectors
+
+Data warehouse connectors (ClickHouse, Snowflake, Redshift, and similar) insert one row per delivered webhook. Credentials and table location alone are not enough—you must also configure:
+
+1. **Table schema** — Column names and types that match your destination table.
+2. **Transformation** — JavaScript that maps each webhook `eventType` and `payload` into a row compatible with that schema.
+
+### Recommended setup flow
+
+1. **Create the destination table** in your warehouse with columns for the fields you want to store (for example, `event_type`, `message_id`, `subscriber_id`, `payload`, `created_at`).
+2. **Grant insert permissions** to the user or role Novu connects with.
+3. **Add the connector endpoint** in Novu and fill in connection settings (URL, credentials, database, table name, and so on).
+4. **Define the table schema** in the connector configuration so it matches your destination table.
+5. **Write the transformation** to map Novu payloads into that schema. Start from the dashboard template and adjust field names and types for your table.
+6. **Subscribe** to the event types you want to store.
+7. **Test** with **Send Example**, confirm success in **Logs**, then query the table to verify rows were inserted.
+
+### Example transformation
+
+This example maps a `message.sent` event into a flat row. Adjust field names to match your table schema and add cases for every event type you subscribe to.
+
+```js
+function handler(webhook) {
+  switch (webhook.eventType) {
+    case "message.sent":
+      webhook.payload = {
+        event_type: webhook.eventType,
+        message_id: webhook.payload.id,
+        subscriber_id: webhook.payload.subscriberId,
+        channel: webhook.payload.channel,
+        created_at: webhook.payload.createdAt,
+        raw_payload: JSON.stringify(webhook.payload),
+      };
+      break;
+    // Add a case for each subscribed event type
+  }
+  return webhook;
+}
+```
+
+If deliveries succeed in Novu but no rows appear in your warehouse, the transformation output likely does not match your table schema. Compare the transformed payload in the **Logs** tab with your table definition.
+
+## Message connectors
+
+Message connectors (Amazon SQS and Amazon SNS) publish each webhook as a queue message or topic notification. Use the transformation to shape the JSON body your consumers receive.
+
+The default template typically forwards the webhook payload. Customize it if downstream workers expect a specific structure (for example, flattening nested fields or adding metadata).
+
+```js
+function handler(webhook) {
+  webhook.payload = {
+    eventType: webhook.eventType,
+    data: webhook.payload,
+    receivedAt: new Date().toISOString(),
+  };
+  return webhook;
+}
+```
+
+After creating the endpoint, send a test event and confirm the message appears in your SQS queue or SNS topic subscription.
 
 ## ClickHouse
 
@@ -47,13 +138,16 @@ The ClickHouse connector stores Novu webhook events directly in a ClickHouse tab
 | Password | Yes | The password for the ClickHouse user. |
 | Table name | Yes | The name of the table where events are stored. |
 | Database | No | The ClickHouse database name. If omitted, the default database is used. |
+| Table schema | Yes | Column definitions that match your ClickHouse table. |
+| Transformation | Yes | JavaScript that maps webhook payloads to rows matching the table schema. |
 
 ### Setup
 
 1. Create a ClickHouse table to receive webhook events.
 2. Ensure the configured user has permission to insert rows into the target table.
-3. In the Novu dashboard, select **ClickHouse** when adding a webhook endpoint and fill in the configuration fields.
-4. Select the event types you want to store and create the endpoint.
+3. In the Novu dashboard, select **ClickHouse** when adding a webhook endpoint.
+4. Fill in connection settings, **table schema**, and **transformation**.
+5. Select event types, create the endpoint, and verify rows with **Send Example**.
 
 ## Snowflake
 
@@ -69,13 +163,16 @@ The Snowflake connector stores Novu webhook events directly in a Snowflake table
 | Database name | No | The Snowflake database where events are stored. |
 | Schema name | No | The schema containing the target table. |
 | Table name | No | The table where events are stored. |
+| Table schema | Yes | Column definitions that match your Snowflake table. |
+| Transformation | Yes | JavaScript that maps webhook payloads to rows matching the table schema. |
 
 ### Setup
 
 1. Create a Snowflake table to receive webhook events.
 2. Configure a Snowflake user with key-pair authentication and insert permissions on the target table.
-3. In the Novu dashboard, select **Snowflake** when adding a webhook endpoint and fill in the configuration fields.
-4. Select the event types you want to store and create the endpoint.
+3. In the Novu dashboard, select **Snowflake** when adding a webhook endpoint.
+4. Fill in connection settings, **table schema**, and **transformation**.
+5. Select event types, create the endpoint, and verify rows with **Send Example**.
 
 ## Amazon Redshift
 
@@ -94,6 +191,8 @@ The Amazon Redshift connector stores Novu webhook events directly in a Redshift 
 | Database name | No | The Redshift database where events are stored. |
 | Schema name | No | The schema containing the target table. |
 | Table name | No | The table where events are stored. |
+| Table schema | Yes | Column definitions that match your Redshift table. |
+| Transformation | Yes | JavaScript that maps webhook payloads to rows matching the table schema. |
 
 <Callout type="info">For provisioned Redshift clusters, set **Cluster identifier** and **Database user**. For Redshift Serverless, set **Workgroup name** instead.</Callout>
 
@@ -101,8 +200,9 @@ The Amazon Redshift connector stores Novu webhook events directly in a Redshift 
 
 1. Create a Redshift table to receive webhook events.
 2. Create an IAM user with the permissions required to write data to Redshift.
-3. In the Novu dashboard, select **Redshift** when adding a webhook endpoint and fill in the configuration fields.
-4. Select the event types you want to store and create the endpoint.
+3. In the Novu dashboard, select **Redshift** when adding a webhook endpoint.
+4. Fill in connection settings, **table schema**, and **transformation**.
+5. Select event types, create the endpoint, and verify rows with **Send Example**.
 
 ## Amazon SQS
 
@@ -117,13 +217,15 @@ The Amazon SQS connector sends Novu webhook events to an Amazon SQS queue. Use i
 | Access key ID | Yes | The AWS access key ID with permission to send messages to the queue. |
 | Secret access key | Yes | The AWS secret access key for the IAM user. |
 | Endpoint URL | No | A custom endpoint URL. Use this when connecting to LocalStack or other SQS-compatible services. |
+| Transformation | Yes | JavaScript that shapes the message body sent to the queue. |
 
 ### Setup
 
 1. Create an SQS queue in your AWS account.
 2. Create an IAM user with `sqs:SendMessage` permission on the target queue.
-3. In the Novu dashboard, select **SQS** when adding a webhook endpoint and fill in the configuration fields.
-4. Select the event types you want to deliver and create the endpoint.
+3. In the Novu dashboard, select **SQS** when adding a webhook endpoint.
+4. Fill in connection settings and review the **transformation**.
+5. Select event types, create the endpoint, and verify messages with **Send Example**.
 
 ## Amazon SNS
 
@@ -138,20 +240,32 @@ The Amazon SNS connector publishes Novu webhook events to an Amazon SNS topic. U
 | Access key ID | Yes | The AWS access key ID with permission to publish to the topic. |
 | Secret access key | Yes | The AWS secret access key for the IAM user. |
 | Endpoint URL | No | A custom endpoint URL. Use this when connecting to LocalStack or other SNS-compatible services. |
+| Transformation | Yes | JavaScript that shapes the notification body published to the topic. |
 
 ### Setup
 
 1. Create an SNS topic in your AWS account.
 2. Create an IAM user with `sns:Publish` permission on the target topic.
-3. In the Novu dashboard, select **SNS** when adding a webhook endpoint and fill in the configuration fields.
-4. Select the event types you want to publish and create the endpoint.
+3. In the Novu dashboard, select **SNS** when adding a webhook endpoint.
+4. Fill in connection settings and review the **transformation**.
+5. Select event types, create the endpoint, and verify messages with **Send Example**.
 
 ## Monitoring and troubleshooting
 
 Connector endpoints support the same delivery monitoring, retry, and recovery features as standard webhook endpoints. From the endpoint details page in the Novu dashboard, you can:
 
 - View delivery attempts and failure reasons in the **Logs** tab.
+- Inspect the transformed payload sent to your destination.
 - Resend individual failed events.
 - Recover or replay failed messages from a selected time window.
 
-If deliveries fail consistently, verify that your connector credentials are valid and that the destination service (database, queue, or topic) is accessible from Novu's webhook infrastructure.
+If deliveries fail consistently, check the following:
+
+| Symptom | What to check |
+| --- | --- |
+| Authentication errors | Connector credentials, IAM permissions, or database user grants. |
+| Schema or type errors | Table schema matches your destination table; transformation output uses the correct column names and types. |
+| Missing rows or messages | Delivery shows success in **Logs** but destination is empty—transformation may not match the expected insert or message format. |
+| Unhandled event types | Transformation includes a branch for every subscribed [event type](/platform/developer/webhooks/event-types). |
+
+If the destination service is unreachable from Novu's webhook infrastructure, deliveries will continue to retry according to the [retry schedule](/platform/developer/webhooks#recovery-and-resending-failed-messages) before the endpoint is disabled.

--- a/content/docs/platform/developer/webhooks/event-types.mdx
+++ b/content/docs/platform/developer/webhooks/event-types.mdx
@@ -2,6 +2,7 @@
 title: 'Event types'
 pageTitle: "Webhooks event types"
 description: 'Learn more about the types of events that Novu sends webhook events for.'
+icon: 'Tags'
 ---
 
 Novu supports the following webhook event types:

--- a/content/docs/platform/developer/webhooks/index.mdx
+++ b/content/docs/platform/developer/webhooks/index.mdx
@@ -40,7 +40,7 @@ When adding or editing an endpoint, you can utilize the advanced configuration o
 
 - **Rate limiting (Throttling)**: You can configure rate limits to effectively throttle the webhooks, ensuring Novu only sends a specific number of requests per second.
 - **Custom headers**: Custom headers can only be configured after the endpoint has been created.
-- **Transformations**: Novu uses Svix transformations feature, it let's you modify a webhook's payload and redirect it to a different URL. <a href="https://docs.svix.com/transformations" target="_blank" rel="noopener noreferrer">Visit Svix documentation</a> to learn more.
+- **Transformations**: Modify a webhook's payload and redirect it to a different URL before delivery.
 
 ### Testing endpoints
 
@@ -59,7 +59,7 @@ After sending an example event, you can view the message payload, all of the mes
 
 You must verify that the requests hitting your endpoint are actually from Novu and not a malicious actor.
 
-Novu uses <a href="https://www.svix.com/" target="_blank" rel="noopener noreferrer">Svix</a> to sign webhooks. Svix offers a set of libraries for verifying signatures.
+Novu signs webhook requests so you can verify that payloads were sent by Novu. Official libraries are available for verifying signatures.
 
 ```tsx
 import { Webhook } from "svix";
@@ -79,7 +79,7 @@ const wh = new Webhook(secret);
 const verifiedPayload = wh.verify(payload, headers);
 ```
 
-Check out the <a href="https://docs.svix.com/receiving/verifying-payloads/how" target="_blank" rel="noopener noreferrer">Svix webhook verification documentation</a>, for more instructions and examples of how to verify signatures.
+See the library documentation for more instructions and examples of how to verify signatures in other languages.
 
 ## Recovery and resending failed messages
 
@@ -182,7 +182,7 @@ For cases where your endpoint is processing complicated workflows, you can have 
 
 To secure your webhook endpoint, you should:
 
-1. Verify the webhook signature using the Svix library
+1. Verify the webhook signature using the official verification library
 2. Use HTTPS for your endpoint URL
 3. Implement rate limiting to prevent abuse
 4. Keep your webhook secret secure and rotate it periodically

--- a/content/docs/platform/developer/webhooks/index.mdx
+++ b/content/docs/platform/developer/webhooks/index.mdx
@@ -6,7 +6,7 @@ description: "Configure webhook endpoints to receive real-time event notificatio
 
 Webhooks makes it possible for your external systems to receive real-time notifications when specific events occur within your Novu account. They are POST requests sent to a pre-determined endpoint that you configure.
 
-<Callout>This webhook feature is only have in the <a href="https://novu.co/pricing" target="_blank" rel="noopener noreferrer">Team and Enterprise plans</a>.</Callout>
+<Callout>Outbound webhooks feature is only available in the <a href="https://novu.co/pricing" target="_blank" rel="noopener noreferrer">Team and Enterprise plans</a>.</Callout>
 
 ## How it works
 
@@ -25,7 +25,7 @@ To start listening to messages, you must register your endpoint in the Novu dash
   ![Webhook integrations list](/images/developer-tools/webhook-integrations.png)
 5. Configure the endpoint:
    - For **Webhook** endpoints, enter the HTTPS URL where you want to receive the payload. You can use tools like [Webhook.site](https://webhook.site/) or [RequestBin](https://requestbin.com/) to generate a temporary URL for testing.
-   - For connector endpoints (such as ClickHouse, Snowflake, Redshift, SQS, or SNS), enter the connector-specific configuration. See the [webhook connectors](/platform/developer/webhooks/connectors) guide for details.
+   - For connector endpoints (such as ClickHouse, Snowflake, Redshift, SQS, or SNS), enter the connector-specific configuration, table schema (for warehouse connectors), and transformation code. See the [webhook connectors](/platform/developer/webhooks/connectors) guide for details.
 6. In the **Description** field, enter a description to identify this webhook.
 7. Next, select the specific event types you want this endpoint to subscribe to.
   ![Add webhook](/images/developer-tools/add-webhook.png)

--- a/content/docs/platform/developer/webhooks/index.mdx
+++ b/content/docs/platform/developer/webhooks/index.mdx
@@ -21,14 +21,16 @@ To start listening to messages, you must register your endpoint in the Novu dash
 1. Go to the **[Webhooks](https://dashboard.novu.co/webhooks)** page in the Novu dashboard.
 2. Select the **Endpoints** tab.
 3. Click **Add Endpoint**.
-4. Select a webhook integration from the list.
+4. Select a webhook integration from the list. Choose **Webhook** to receive events over HTTP, or select a [connector](/platform/developer/webhooks/connectors) to deliver events directly to a data warehouse or AWS messaging service.
   ![Webhook integrations list](/images/developer-tools/webhook-integrations.png)
-4. In the **Endpoint URL** field, enter the HTTPS URL where you want to receive the payload. You can use tools like [Webhook.site](https://webhook.site/) or [RequestBin](https://requestbin.com/) to generate a temporary URL for testing.
-5. In the **Description** field, enter a description to identify this webhook.
-6. Next, select the specific event types you want this endpoint to subscribe to.
+5. Configure the endpoint:
+   - For **Webhook** endpoints, enter the HTTPS URL where you want to receive the payload. You can use tools like [Webhook.site](https://webhook.site/) or [RequestBin](https://requestbin.com/) to generate a temporary URL for testing.
+   - For connector endpoints (such as ClickHouse, Snowflake, Redshift, SQS, or SNS), enter the connector-specific configuration. See the [webhook connectors](/platform/developer/webhooks/connectors) guide for details.
+6. In the **Description** field, enter a description to identify this webhook.
+7. Next, select the specific event types you want this endpoint to subscribe to.
   ![Add webhook](/images/developer-tools/add-webhook.png)
-7. (Optional) Configure [advanced settings](/platform/developer/webhooks#advanced-configuration) for rate limits, transformations, and custom headers.
-8. Click **Create**.
+8. (Optional) Configure [advanced settings](/platform/developer/webhooks#advanced-configuration) for rate limits, transformations, and custom headers.
+9. Click **Create**.
 
 <Callout>For frameworks that enable CSRF protection disable them and also verify the signature and timestamp when processing them.</Callout>
 

--- a/content/docs/platform/developer/webhooks/meta.json
+++ b/content/docs/platform/developer/webhooks/meta.json
@@ -1,4 +1,4 @@
 {
   "icon": "Webhook",
-  "pages": ["event-types"]
+  "pages": ["event-types", "connectors"]
 }

--- a/content/docs/platform/developer/webhooks/webhooks.mdx
+++ b/content/docs/platform/developer/webhooks/webhooks.mdx
@@ -88,9 +88,7 @@ After sending an example event, you can view the message payload, all of the mes
 
 Webhook signatures let you verify that webhook messages are actually sent by Novu and not a malicious actor.
 
-For a more detailed explanation, check out this article on [why you should verify webhooks](https://docs.svix.com/receiving/verifying-payloads/why).
-
-Our webhook partner Svix offers a set of useful libraries that make verifying webhooks very simple. Here is an example using Javascript:
+Verifying webhook signatures helps ensure payloads were sent by Novu and have not been tampered with. Here is an example using JavaScript:
 
 ```javascript
 import { Webhook } from "svix";
@@ -110,7 +108,7 @@ const wh = new Webhook(secret);
 const verifiedPayload = wh.verify(payload, headers);
 ```
 
-For more instructions and examples of how to verify signatures, check out the [webhook verification documentation](https://docs.svix.com/receiving/verifying-payloads/how).
+See the library documentation for more instructions and examples of how to verify signatures in other languages.
 
 ## Retry schedule
 
@@ -191,7 +189,7 @@ From there, you can click "Replay..." and choose to "Replay all failed messages 
 
 To secure your webhook endpoint, you should:
 
-1. Verify the webhook signature using the Svix library
+1. Verify the webhook signature using the official verification library
 2. Use HTTPS for your endpoint URL
 3. Implement rate limiting to prevent abuse
 4. Keep your webhook secret secure and rotate it periodically


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Documents the newly available webhook connectors in the Novu dashboard: ClickHouse, Snowflake, Amazon Redshift, Amazon SQS, and Amazon SNS. These connectors let users route Novu webhook events directly to data warehouses and AWS messaging services.

## Changes

- Added a new Webhook connectors page with configuration fields and setup steps for each connector.
- Updated the webhooks overview to distinguish between standard HTTP endpoints and connector endpoints.
- Added the connectors page to the webhooks navigation.
- Removed Svix brand mentions from webhook documentation pages.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [DOC-343](https://linear.app/novu/issue/DOC-343/document-new-webhook-vendor-connectors)

<div><a href="https://cursor.com/agents/bc-263e3358-3bd1-4204-8e62-000054b0d92a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-263e3358-3bd1-4204-8e62-000054b0d92a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive guide for setting up and configuring webhook connectors with supported integration types and transformation examples.
  * Enhanced webhook verification documentation with clearer instructions for securing webhook endpoints.
  * Improved webhook documentation organization for better accessibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

- Adds a new webhook connectors guide covering ClickHouse, Snowflake, Amazon Redshift, Amazon SQS, and Amazon SNS.
- Updates webhook overview content to distinguish standard HTTP endpoints from connector endpoints.
- Adds the connectors page to webhook navigation and revises existing webhook verification wording.

<h3>Confidence Score: 3/5</h3>

The changes are documentation-only, but several connector setup instructions can lead users to incomplete or invalid webhook configurations.

The review focused on the changed webhook documentation and identified concrete places where required configuration, event handling, timestamp semantics, and verification guidance are misleading or incomplete.

content/docs/platform/developer/webhooks/connectors.mdx, content/docs/platform/developer/webhooks/index.mdx

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex attempted to run the real app locally by starting the Next.js dev server with PORT=3011 and navigated to the requested routes using Playwright Chromium.
- The saved server and capture logs document the executed commands, initial Playwright/browser dependency setup, and blockers encountered, including the route render timeout.
- No accepted before/after UI video pair was produced, so the evaluation remains inconclusive rather than derived from source inspection.
- In the base behavior, the connectors guide is missing, index.mdx has four direct Svix brand mentions, webhooks.mdx has two, and the validation exits with code 1.
- In the head behavior, connectors.mdx is present; each named connector has configuration\_subsection=True and setup\_subsection=True; index.mdx and webhooks.mdx have direct\_brand\_mentions=0; the validation exits with code 0.
- The validation script artifact is included so the executed checks are reproducible.

<a href="https://app.greptile.com/trex/runs/11367425/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=1" height="32"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%207%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%207%0Acontent%2Fdocs%2Fplatform%2Fdeveloper%2Fwebhooks%2Findex.mdx%3A82%0A**Restore%20verification%20reference**%0A%0ABoth%20this%20page%20and%20%60content%2Fdocs%2Fplatform%2Fdeveloper%2Fwebhooks%2Fwebhooks.mdx%60%20still%20show%20the%20%60svix%60%20%60Webhook%60%20verifier%2C%20but%20the%20follow-up%20prose%20now%20points%20readers%20only%20to%20unspecified%20%E2%80%9Clibrary%20documentation%E2%80%9D%20without%20naming%20or%20linking%20that%20library.%20Users%20setting%20up%20verification%20in%20another%20language%2C%20or%20trying%20to%20install%20and%20use%20the%20shown%20package%20correctly%2C%20lose%20the%20concrete%20verification%20docs%20path%20and%20can%20end%20up%20skipping%20or%20misimplementing%20signature%20checks.%0A%0A%23%23%23%20Issue%202%20of%207%0Acontent%2Fdocs%2Fplatform%2Fdeveloper%2Fwebhooks%2Fconnectors.mdx%3A165%0A**Require%20target%20tables**%0A%0AThe%20Snowflake%20and%20Redshift%20connector%20sections%20describe%20inserting%20rows%20into%20a%20destination%20table%2C%20but%20both%20configuration%20tables%20mark%20%60Table%20name%60%20as%20optional.%20If%20a%20user%20follows%20the%20docs%20and%20leaves%20this%20blank%2C%20the%20connector%20has%20no%20target%20table%20to%20write%20transformed%20rows%20into%2C%20so%20setup%20cannot%20complete%20or%20deliveries%20can%20fail%20at%20insert%20time.%20Please%20mark%20%60Table%20name%60%20as%20required%20for%20both%20Snowflake%20and%20Redshift.%0A%0A%23%23%23%20Issue%203%20of%207%0Acontent%2Fdocs%2Fplatform%2Fdeveloper%2Fwebhooks%2Fconnectors.mdx%3A10%0A**Keep%20branding%20consistent**%0A%0AThe%20surrounding%20webhook%20pages%20were%20changed%20to%20remove%20direct%20Svix%20brand%20references%2C%20but%20this%20new%20connectors%20page%20introduces%20a%20prominent%20Svix%20mention%20and%20link%20in%20the%20opening%20section.%20If%20the%20product-facing%20docs%20are%20meant%20to%20avoid%20vendor%20branding%2C%20the%20webhooks%20section%20now%20gives%20conflicting%20guidance%20across%20pages.%0A%0A%23%23%23%20Issue%204%20of%207%0Acontent%2Fdocs%2Fplatform%2Fdeveloper%2Fwebhooks%2Fconnectors.mdx%3A188-193%0A**Mark%20conditional%20requirements**%0A%0AThis%20table%20marks%20all%20Redshift%20target%20fields%20as%20optional%2C%20while%20the%20callout%20below%20says%20provisioned%20clusters%20require%20%60Cluster%20identifier%60%20and%20%60Database%20user%60%2C%20and%20serverless%20requires%20%60Workgroup%20name%60.%20A%20user%20can%20follow%20the%20table%2C%20omit%20all%20of%20these%20fields%2C%20and%20end%20up%20with%20an%20invalid%20Redshift%20connector%20configuration.%20Please%20mark%20the%20Redshift%20fields%20as%20conditionally%20required%20based%20on%20provisioned%20versus%20serverless%20setup.%0A%0A%23%23%23%20Issue%205%20of%207%0Acontent%2Fdocs%2Fplatform%2Fdeveloper%2Fwebhooks%2Fconnectors.mdx%3A89-103%0A**Handle%20unmatched%20events**%0A%0AThis%20sample%20only%20maps%20%60message.sent%60.%20For%20any%20other%20subscribed%20event%20type%2C%20the%20%60switch%60%20falls%20through%20and%20returns%20the%20original%20webhook%20payload%2C%20so%20a%20copied%20transformation%20can%20try%20to%20insert%20a%20raw%20event%20shape%20into%20the%20warehouse%20table%20and%20fail%20schema%20validation%20or%20create%20bad%20rows.%0A%0A%23%23%23%20Issue%206%20of%207%0Acontent%2Fdocs%2Fplatform%2Fdeveloper%2Fwebhooks%2Fconnectors.mdx%3A120%0A**Avoid%20replay%20timestamps**%0A%0A%60new%20Date%28%29%60%20records%20when%20the%20transformation%20runs%2C%20not%20when%20the%20Novu%20event%20happened.%20During%20retries%20or%20recovery%2C%20old%20events%20can%20be%20republished%20with%20a%20fresh%20%60receivedAt%60%2C%20so%20downstream%20workers%20or%20analytics%20can%20treat%20replayed%20events%20as%20new%20current%20events.%0A%0A%23%23%23%20Issue%207%20of%207%0Acontent%2Fdocs%2Fplatform%2Fdeveloper%2Fwebhooks%2Fconnectors.mdx%3A21-25%0A**Select%20events%20first**%0A%0AThese%20steps%20tell%20users%20to%20write%20the%20connector%20schema%20and%20transformation%20before%20selecting%20event%20types%2C%20but%20the%20transformation%20must%20handle%20every%20subscribed%20event%20type.%20That%20ordering%20encourages%20users%20to%20configure%20a%20transformation%20before%20they%20know%20the%20complete%20set%20of%20event%20shapes%20it%20must%20map%2C%20which%20can%20leave%20subscribed%20events%20unhandled.%0A%0A&pr=1123&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 7 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 7
content/docs/platform/developer/webhooks/index.mdx:82
**Restore verification reference**

Both this page and `content/docs/platform/developer/webhooks/webhooks.mdx` still show the `svix` `Webhook` verifier, but the follow-up prose now points readers only to unspecified “library documentation” without naming or linking that library. Users setting up verification in another language, or trying to install and use the shown package correctly, lose the concrete verification docs path and can end up skipping or misimplementing signature checks.

### Issue 2 of 7
content/docs/platform/developer/webhooks/connectors.mdx:165
**Require target tables**

The Snowflake and Redshift connector sections describe inserting rows into a destination table, but both configuration tables mark `Table name` as optional. If a user follows the docs and leaves this blank, the connector has no target table to write transformed rows into, so setup cannot complete or deliveries can fail at insert time. Please mark `Table name` as required for both Snowflake and Redshift.

### Issue 3 of 7
content/docs/platform/developer/webhooks/connectors.mdx:10
**Keep branding consistent**

The surrounding webhook pages were changed to remove direct Svix brand references, but this new connectors page introduces a prominent Svix mention and link in the opening section. If the product-facing docs are meant to avoid vendor branding, the webhooks section now gives conflicting guidance across pages.

### Issue 4 of 7
content/docs/platform/developer/webhooks/connectors.mdx:188-193
**Mark conditional requirements**

This table marks all Redshift target fields as optional, while the callout below says provisioned clusters require `Cluster identifier` and `Database user`, and serverless requires `Workgroup name`. A user can follow the table, omit all of these fields, and end up with an invalid Redshift connector configuration. Please mark the Redshift fields as conditionally required based on provisioned versus serverless setup.

### Issue 5 of 7
content/docs/platform/developer/webhooks/connectors.mdx:89-103
**Handle unmatched events**

This sample only maps `message.sent`. For any other subscribed event type, the `switch` falls through and returns the original webhook payload, so a copied transformation can try to insert a raw event shape into the warehouse table and fail schema validation or create bad rows.

### Issue 6 of 7
content/docs/platform/developer/webhooks/connectors.mdx:120
**Avoid replay timestamps**

`new Date()` records when the transformation runs, not when the Novu event happened. During retries or recovery, old events can be republished with a fresh `receivedAt`, so downstream workers or analytics can treat replayed events as new current events.

### Issue 7 of 7
content/docs/platform/developer/webhooks/connectors.mdx:21-25
**Select events first**

These steps tell users to write the connector schema and transformation before selecting event types, but the transformation must handle every subscribed event type. That ordering encourages users to configure a transformation before they know the complete set of event shapes it must map, which can leave subscribed events unhandled.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(webhooks): enhance webhook connecto..."](https://github.com/novuhq/docs/commit/fce47ba259a2f3450ed2082d722e3c1a2be762a8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38078982)</sub>

> Greptile also left **7 inline comments** on this PR.

<!-- /greptile_comment -->