### PR TITLE
Update content to change language to client-facing, update quickstart

### DIFF
--- a/content/docs/agents/get-started/what-is-aci.mdx
+++ b/content/docs/agents/get-started/what-is-aci.mdx
@@ -9,7 +9,14 @@ import { BookText, HomeIcon } from 'lucide-react';
  
 Agent Communication Infrastructure (ACI) is the communication layer that connects agents to the messaging platforms where people already work, collaborate, and talk to businesses.
 
-ACI sits between communication channels and your agent logic. Instead of building separate integrations for Slack, Microsoft Teams, WhatsApp, email, Telegram, and other platforms, ACI gives your agent one communication interface for inbound messages, outbound replies, conversation state, user identity, and delivery.
+ACI sits between communication channels and your agent logic. Instead of building separate integrations for each platform, ACI gives your agent one communication interface for inbound messages, outbound replies, conversation state, user identity, and delivery across:
+
+* Slack
+* Microsoft Teams
+* WhatsApp
+* Email
+* Telegram
+* Other supported platforms
 
 The agent brain can be powered by an LLM, custom code, a rules engine, a human-in-the-loop workflow, a managed agent platform, or a combination of systems. ACI does not define the agent’s intelligence. It defines the communication infrastructure around it.
 
@@ -37,7 +44,14 @@ ACI introduces a three-part architecture that separates platform delivery from a
 
 ### Communication channels
 
-Communication channels are the places where people interact with the agent, such as Slack, Microsoft Teams, WhatsApp, Telegram, email, and other supported platforms.
+Communication channels are the places where people interact with the agent:
+
+* Slack
+* Microsoft Teams
+* WhatsApp
+* Telegram
+* Email
+* Other supported platforms
 
 When a user sends a message in one of these channels, the message enters the ACI layer.
 
@@ -57,7 +71,14 @@ For a custom code agent, your server receives the context object and processes i
 
 For a managed agent, you configure the agent's behavior, system prompt, tools, skills, and external connections. The managed platform runs the agent harness and executes the agent loop, while ACI handles the communication layer between the managed agent and your connected channels.
 
-Because the agent brain is separate from the channel layer, your agent does not need channel-specific logic for each connected provider. The same agent can respond across Slack, Microsoft Teams, WhatsApp, email, Telegram, or other supported channels through the ACI bridge.
+Because the agent brain is separate from the channel layer, your agent does not need channel-specific logic for each connected provider. The same agent can respond through the ACI bridge across:
+
+* Slack
+* Microsoft Teams
+* WhatsApp
+* Email
+* Telegram
+* Other supported channels
 
 
 ## What ACI handles and what you control

--- a/content/docs/agents/get-started/what-is-aci.mdx
+++ b/content/docs/agents/get-started/what-is-aci.mdx
@@ -109,7 +109,7 @@ Common use cases include:
 
 ## Start building
 
-Follow the quickstart to create your first agent, connect a Slack provider, and send your first message in under 5 minutes.
+Follow the quickstart to create your first agent, connect a Slack provider, and send your first message in under five minutes.
 
 <Cards>
   <Card

--- a/content/docs/agents/get-started/what-is-aci.mdx
+++ b/content/docs/agents/get-started/what-is-aci.mdx
@@ -87,7 +87,7 @@ For a managed agent, you configure:
 
 - The agent's instructions and behavior.
 - MCP servers and their configuration.
-- The agent's tools, skill and their configuration.
+- The agent's tools, skills and their configuration.
 - The external systems the agent can access.
 - The guardrails or constraints supported by the managed platform.
 

--- a/content/docs/agents/get-started/what-is-aci.mdx
+++ b/content/docs/agents/get-started/what-is-aci.mdx
@@ -6,26 +6,28 @@ icon: CircleHelp
 ---
 
 import { BookText, HomeIcon } from 'lucide-react';
+ 
+Agent Communication Infrastructure (ACI) is the communication layer that connects agents to the messaging platforms where people already work, collaborate, and talk to businesses.
 
-Agent Communication Infrastructure (ACI) is a protocol-driven infrastructure layer for enabling structured, stateful communication between autonomous agents and your users across messaging platforms.
+ACI sits between communication channels and your agent logic. Instead of building separate integrations for Slack, Microsoft Teams, WhatsApp, email, Telegram, and other platforms, ACI gives your agent one communication interface for inbound messages, outbound replies, conversation state, user identity, and delivery.
 
-ACI sits between messaging platforms and your agent logic. Instead of building separate integrations for each channel, ACI provides a unified interface for webhooks, message delivery, conversation state, and subscriber identity.
+The agent brain can be powered by an LLM, custom code, a rules engine, a human-in-the-loop workflow, a managed agent platform, or a combination of systems. ACI does not define the agent’s intelligence. It defines the communication infrastructure around it.
 
-The agent itself can be powered by an LLM, custom code, a rules engine, a human-in-the-loop workflow, or a combination of systems or Platform managed agents like [Claude Managed Agent](https://platform.claude.com/docs/en/managed-agents/overview), [ AWS Bedrock AgentCore](https://aws.amazon.com/bedrock/agentcore/) and many more. ACI doesn't define the agent’s intelligence. It defines the communication infrastructure around it.
+That means you can build an agent that your team uses internally, expose an agent to your product users, or create a customer-facing agent that lives in the channels your customers already use.
 
 ## What does ACI solve?
 
-Software is becoming more conversational. Users no longer only click through interfaces or receive one-way notifications. They ask questions, reply to messages, clarify requests, approve actions, send files, react with emojis, and expect software to continue the conversation in channels where they already are.
+Software is becoming more conversational. People no longer only click through interfaces or receive one-way notifications. They ask questions, reply to messages, clarify requests, approve actions, send files, react with emojis, and expect software to continue the conversation in the channels where they already are.
 
-At the same time, agents are becoming more capable. And most teams already have agents that answers users questions, analyze information, trigger workflows, escalate issues, and coordinate with other systems.
+At the same time, agents are becoming more capable. Teams are building agents that answer questions, analyze information, trigger workflows, escalate issues, and coordinate with other systems.
 
-In most cases, these agents only work inside one platform, getting these agents into a different platform requires rebuilding the communication layer from scratch.
+The problem is that most agents are still trapped inside one interface. Moving the same agent into Slack, Microsoft Teams, WhatsApp, email, Telegram, or another channel usually means rebuilding the communication layer for each platform.
 
-This creates an infrastructure problem where each channel has its own webhook format, identity model, threading behavior, permissions, message formatting, interaction patterns, and delivery constraints. Teams that want to expose an agent across Slack, Microsoft Teams, WhatsApp, email, or other channels often end up rebuilding the same communication plumbing for every channel.
+Each channel has its own webhook format, identity model, threading behavior, permissions, message formatting, interaction patterns, and delivery constraints. Without a shared communication layer, teams end up rebuilding the same infrastructure every time they want an agent to reach a new audience.
 
-ACI exists to standardize that layer. It separates the communication layer from the agent logic, so teams can connect agents to different messaging platforms without hand-building every channel integration from scratch.
+ACI standardizes that layer. It separates communication infrastructure from agent intelligence, so you can connect an agent to multiple messaging platforms without hand-building every channel integration from scratch.
 
-You create your agent once. ACI handles delivery everywhere. The goal isn't only to send messages but to let agents hold useful conversations across channels while preserving context, control, and visibility.
+You create the agent once. ACI handles communication across connected channels. The goal is not only to send messages, but to let agents hold useful conversations while preserving context, control, and visibility.
 
 ## How ACI works
 
@@ -35,31 +37,34 @@ ACI introduces a three-part architecture that separates platform delivery from a
 
 ### Communication channels
 
-Communication channels are the places where users interact with the agent, such as Slack, Microsoft Teams, WhatsApp, Telegram, and more. When a user sends a message on any of these platforms, it enters the ACI layer.
+Communication channels are the places where people interact with the agent, such as Slack, Microsoft Teams, WhatsApp, Telegram, email, and other supported platforms.
+
+When a user sends a message in one of these channels, the message enters the ACI layer.
 
 ### Bridge
 
-The bridge is the infrastructure layer in the middle. It receives the platform webhook, normalizes the message into a standard format, and resolves the user's identity. 
+The bridge is the infrastructure layer between the communication channel and the agent's brain.
 
-It creates or loads the conversation with its full history, and forwards everything to your server as a single context object.
+It receives the platform webhook, normalizes the message into a standard format, and resolves the user's identity. It then creates or loads the conversation, attaches the relevant conversation history, and forwards the message to your configured agent brain as context.
 
-When your agent replies, the bridge delivers the response back to the correct platform thread, persists it in the conversation history, and records the activity. 
+When the agent replies, the bridge delivers the response back to the correct platform, thread, or conversation. It also persists the response in the conversation history and records the activity for observability.
 
-### Agent brain
+### Agent
 
-The agent brain is either Custom code agent or Managed agent.
+The agent's brain is the system that decides how to respond. ACI supports different kinds of agents, including custom code agents and managed agents.
 
-In case of Custom code agent, you can build agent brain with your custom code using agent sdk, lanchain etc. Your server receives the context object and processes it however you decide. Call an LLM, run business logic, route to a human, or combine all three.
+For a custom code agent, your server receives the context object and processes it however you decide. You can call an LLM, run business logic, use external APIs, route the conversation to a human, or combine multiple systems. You can build the agent brain with the Novu agent SDK, AI SDK, LangChain, OpenAI SDK, or any custom code of your choosing.
 
-In case of Managed agent, platfrom like Claude manages the agent intelligence, it provides, system tools like grep, web search, connection to external tools like linear, notion using MCP.
+For a managed agent, you configure the agent's behavior, system prompt, tools, skills, and external connections. The managed platform runs the agent harness and executes the agent loop, while ACI handles the communication layer between the managed agent and your connected channels.
 
-The channel-agnostic nature of this architecture means that when you connect a new provider, your agent implementation doesn't change. Not a single line of code. The same brain that responds on Slack will respond on Microsoft Teams, WhatsApp, or email without modification.
+Because the agent brain is separate from the channel layer, your agent does not need channel-specific logic for each connected provider. The same agent can respond across Slack, Microsoft Teams, WhatsApp, email, Telegram, or other supported channels through the ACI bridge.
 
-## What ACI handles vs. what you control
 
-ACI draws a clear boundary between infrastructure and intelligence.
+## What ACI handles and what you control
 
-### The infrastructure handles
+ACI draws a clear boundary between communication infrastructure and agent intelligence.
+
+### ACI handles
 
 * Webhook ingestion and message normalization across all connected platforms.
 * Message delivery to the correct platform thread.
@@ -70,7 +75,7 @@ ACI draws a clear boundary between infrastructure and intelligence.
 
 ### You control
 
-In case of _Custom code agent_, you control:
+For a custom code agent, you control:
 
 * Your LLM, prompts, and model configuration.
 * Your tools and function calls.
@@ -78,13 +83,15 @@ In case of _Custom code agent_, you control:
 * Your API keys and credentials.
 * Your choice of runtime, which can be managed agents, Vercel AI SDK, LangChain, OpenAI SDK, or any custom code of your choosing.
 
-In case of _Managed agent_, platform like Claude controls:
+For a managed agent, you configure:
 
+- The agent's instructions and behavior.
 - MCP servers and their configuration.
-- The agent's tools and their configuration.
-- The agent's business logic and decision-making.
+- The agent's tools, skill and their configuration.
+- The external systems the agent can access.
+- The guardrails or constraints supported by the managed platform.
 
-ACI is opinionated about infrastructure and unopinionated about intelligence. It handles the delivery problem so you can focus on the capability problem.
+ACI is opinionated about communication infrastructure and unopinionated about intelligence. It handles the communication problem so you can focus on what your agent should do.
 
 ## Common use cases
 
@@ -101,6 +108,8 @@ Common use cases include:
 * Multi-channel agents that need one communication interface across several providers.
 
 ## Start building
+
+Follow the quickstart to create your first agent, connect a Slack provider, and send your first message in under 5 minutes.
 
 <Cards>
   <Card

--- a/content/docs/agents/index.mdx
+++ b/content/docs/agents/index.mdx
@@ -78,7 +78,7 @@ Explore the full documentation to go deeper on any part of Novu Connect.
     How agents and provider connections work, and which channels are supported.
   </Card>
   <Card href="/agents/managed-agent/overview" title="Managed agent" icon={<Sparkles />}>
-    Configure a fully managed agent powered by Claude.
+    Configure a fully-managed agent powered by Claude.
   </Card>
   <Card href="/agents/custom-code-agent/quickstart" title="Custom code quickstart" icon={<Zap />}>
     Connect a Slack provider and send your first message in under five minutes.

--- a/content/docs/agents/index.mdx
+++ b/content/docs/agents/index.mdx
@@ -1,0 +1,89 @@
+---
+title: "Overview"
+pageTitle: "Agents"
+description: "Connect your AI agents to chat platforms and communication channels with Novu's Agent Communication Infrastructure (ACI)."
+icon: Plug
+---
+
+import { Code2, Sparkles, BrainCircuit, Blocks, MessagesSquare, CircleHelp, Zap } from 'lucide-react';
+
+Novu Connect is built on the [Agent Communication Infrastructure (ACI)](/agents/get-started/what-is-aci), the infrastructure layer that handles how agents communicate, so your agents can hold real conversations across messaging platforms with users, on the channels they already use.
+
+ACI draws a hard boundary between two concerns:
+
+* **Communication infrastructure**: Webhook ingestion, message normalization, conversation state, identity resolution, and delivery across channels. ACI owns this layer.
+
+* **Agent intelligence**: Your LLM, prompts, tools, managed agent configuration, business logic, or custom runtime. You own this layer.
+
+The result is that you can create an agent once and make it available across connected channels. ACI routes messages in, sends replies out, preserves conversation context, and removes the need to rebuild communication plumbing for every platform.
+
+<Card href="/agents/get-started/what-is-aci" title="What is ACI?" icon={<CircleHelp />}>
+  Learn how ACI works, what it solves, and where it draws the line between infrastructure and intelligence.
+</Card>
+
+## Connect the agent
+
+Novu Connect accepts two kinds of agents. You choose how you want to bring the intelligence.
+
+Novu Connect accepts two kinds of agent brains. You choose how you want to bring the intelligence.
+
+
+### External connectors
+
+Delegate the agent logic entirely to a managed platform such as Claude Managed Agents. You configure the agent's behavior, system prompt, tools, skills, and MCP servers and the platform runs the intelligence.
+
+<Card href="/agents/managed-agent/overview" title="Managed agent" icon={<Sparkles />}>
+  Set up a fully managed agent powered by Claude. No custom server code required.
+</Card>
+
+### Custom code
+
+Write your own agent logic. Handle events, call any LLM or API, and reply using the Novu agent SDK. Compatible with AI SDK, LangChain, OpenAI SDK, and any custom code of your choosing.
+
+<Card href="/agents/custom-code-agent/quickstart" title="Custom code agent" icon={<Code2 />}>
+  Build an agent with full control over logic, tools, and event handling.
+</Card>
+
+## How a conversation flows
+
+ACI turns channel-specific messages into a standard communication flow between the user and your agent brain.
+
+1. A user sends a message on Slack, Teams, WhatsApp, or another supported channel.
+2. Novu ingests the webhook, normalizes the event, and resolves the user's identity.
+3. Novu sends the event to your agent brain with full conversation context.
+4. Your agent processes the message and responds. 
+5. Novu delivers the reply back to the correct platform thread.
+6. Novu persists the conversation and makes it visible in the Connect dashboard.
+
+## Start building
+
+Follow the quickstart to create your first agent, connect a Slack provider, and send your first message in under 5 minutes.
+
+<Card href="/agents/managed-agent/quickstart" title="Quickstart" icon={<Zap />}>
+  Connect a Slack provider and send your first message in under 5 minutes.
+</Card>
+
+## Learn more
+
+Explore the full documentation to go deeper on any part of Novu Connect.
+
+<Cards>
+  <Card href="/agents/get-started/what-is-aci" title="What is ACI?" icon={<CircleHelp />}>
+    Understand the infrastructure layer and the problem it solves.
+  </Card>
+  <Card href="/agents/get-started/mental-model" title="Mental model" icon={<BrainCircuit />}>
+    How inbound messages flow from a channel through to your agent and back.
+  </Card>
+  <Card href="/agents/get-started/agents-and-providers" title="Agents and providers" icon={<Blocks />}>
+    How agents and provider connections work, and which channels are supported.
+  </Card>
+  <Card href="/agents/managed-agent/overview" title="Managed agent" icon={<Sparkles />}>
+    Configure a fully managed agent powered by Claude.
+  </Card>
+  <Card href="/agents/custom-code-agent/quickstart" title="Custom code quickstart" icon={<Zap />}>
+    Connect a Slack provider and send your first message in under 5 minutes.
+  </Card>
+  <Card href="/agents/conversations" title="Conversation observability" icon={<MessagesSquare />}>
+    Monitor, inspect, and manage live agent conversations.
+  </Card>
+</Cards>

--- a/content/docs/agents/index.mdx
+++ b/content/docs/agents/index.mdx
@@ -54,10 +54,8 @@ ACI turns channel-specific messages into a standard communication flow between t
 
 ## Start building
 
-Follow the quickstart to create your first agent, connect a Slack provider, and send your first message in under 5 minutes.
-
 <Card href="/agents/managed-agent/quickstart" title="Quickstart" icon={<Zap />}>
-  Connect a Slack provider and send your first message in under 5 minutes.
+  Follow the quickstart to create your first agent, connect a Slack provider, and send your first message in under 5 minutes.
 </Card>
 
 ## Learn more

--- a/content/docs/agents/index.mdx
+++ b/content/docs/agents/index.mdx
@@ -23,10 +23,7 @@ The result is that you can create an agent once and make it available across con
 
 ## Connect the agent
 
-Novu Connect accepts two kinds of agents. You choose how you want to bring the intelligence.
-
-Novu Connect accepts two kinds of agent brains. You choose how you want to bring the intelligence.
-
+Novu Connect accepts two kinds of [agent brains](/platform/additional-resources/glossary#agent-brain). You choose how you want to bring it.
 
 ### External connectors
 

--- a/content/docs/agents/index.mdx
+++ b/content/docs/agents/index.mdx
@@ -81,7 +81,7 @@ Explore the full documentation to go deeper on any part of Novu Connect.
     Configure a fully managed agent powered by Claude.
   </Card>
   <Card href="/agents/custom-code-agent/quickstart" title="Custom code quickstart" icon={<Zap />}>
-    Connect a Slack provider and send your first message in under 5 minutes.
+    Connect a Slack provider and send your first message in under five minutes.
   </Card>
   <Card href="/agents/conversations" title="Conversation observability" icon={<MessagesSquare />}>
     Monitor, inspect, and manage live agent conversations.

--- a/content/docs/agents/managed-agent/quickstart.mdx
+++ b/content/docs/agents/managed-agent/quickstart.mdx
@@ -35,16 +35,17 @@ npx novu connect
 
 ## Create an agent
 
-1. Choose where your agent runs. The CLI asks **Where do you want the agent to run?** , select an option and then press **Enter**:
-    * **Demo credentials**: The fastest way to start. No Anthropic API key required (Novu handles it), with up to 10 conversations per month.
-    * **Claude Managed Agents**: Bring your own Anthropic API key.
-    * **AWS Claude Managed Agents**: Use your AWS Claude credentials (API key, region, and workspace ID).
+1. Choose where your agent runs. The CLI asks **Where do you want the agent to run?**, select an option, and then press **Enter**:
+    * Demo credentials
+    * Claude Managed Agents
+    * AWS Claude Managed Agents
+
     For this quickstart, select **Demo credentials**.
-2. Describe your agent. Type a description of what you want the agent to do and press **Enter**.
+2. Describe your agent. Type a description of what you want the agent to do and press **Enter**. For example:
     ```text
     Create an engineering assistant agent that checks Linear and GitHub for open issues, pending PR reviews, and review requests. It summarizes what needs attention, flags blockers and stale tickets, and posts a short daily standup digest. It keeps responses concise and links back to the relevant Linear issue or GitHub pull request.
     ```
-    Novu will generate the agent for you, including its system prompt, tools, MCP servers, and skills based on your description.
+    Novu generates the agent for you, including its system prompt, tools, MCP servers, and skills based on your description.
 3. Review and create the agent. The CLI shows the generated agent for you to review. You can adjust any of the following fields before confirming:
       * Name
       * Identifier
@@ -84,7 +85,7 @@ Once installed, your agent is live and listening for messages in Slack.
 
 ## Send a message
 
-Open Slack, where you'll see a message from your agent. Send it a direct message to get started. You'll then be prompted by the agent to connect your Linear and GitHub MCP servers, once you do, your agent is ready.
+Open Slack, where you see a message from your agent. Send it a direct message to get started. The agent then prompts you to connect your Linear and GitHub MCP servers; once you do, your agent is ready.
  
 You can also add and interact with the agent in any channel in the workspace.
  

--- a/content/docs/agents/managed-agent/quickstart.mdx
+++ b/content/docs/agents/managed-agent/quickstart.mdx
@@ -65,7 +65,7 @@ npx novu connect
 
 The CLI prompts you: **pick a channel to connect this agent to.** Select **Slack** and press **Enter**.
  
-Novu will ask you to paste a Slack App Configuration Token. To get one:
+Novu asks you to paste a Slack App Configuration Token. To get one:
 1. Open [https://api.slack.com/apps](https://api.slack.com/apps).
 2. Scroll to the bottom of the page.
 3. Under **App Configuration Tokens**, click **Generate Token**.

--- a/content/docs/agents/managed-agent/quickstart.mdx
+++ b/content/docs/agents/managed-agent/quickstart.mdx
@@ -1,83 +1,82 @@
 ---
 title: "Quickstart"
 pageTitle: 'Managed Agent Quickstart'
-description: 'Create a managed agent with Claude, connect it to Slack, and get a reply in under 10 minutes.'
+description: 'Use the Novu CLI to create a managed agent, connect it to Slack, and get a reply in minutes.'
 icon: Zap
 ---
 
 import { Brain, Link, MessagesSquare } from 'lucide-react';
 
-This guide walks you through creating a managed agent powered by Claude, connecting it to Slack, and sending your first message.
+This guide walks you through creating a managed agent using the Novu CLI, connecting it to Slack, and sending your first message.
 
-By the end, you will have a working agent that receives messages from Slack and replies using Claude's reasoning.
+![Novu connect demo](/images/agents/quickstart/novu-connect-demo.gif)
 
-**Prerequisites:**
+## Prerequisites
 
-- A [Novu account](https://dashboard.novu.co).
-- A Slack workspace where you can install apps.
-- A Claude API key from the [Anthropic console](https://console.anthropic.com/settings/keys) (optional, you can use Novu demo credentials to start).
+* Node.js installed on your machine.
+* A [Novu account](https://connect.novu.co/) (you can create one during the setup flow).
+* A Slack workspace where you can install apps.
 
 <Steps>
 
 <Step>
 
-## Create your agent
+## Run the CLI
 
-1. Go to the [Novu dashboard](https://dashboard.novu.co).
-2. In the sidebar, click **Agents**.
-3. Click **Add Agent**.
-4. Under **External connectors**, select **Claude Managed Agent**.
+In your terminal, run:
 
-</Step>
-
-<Step>
-
-## Configure the connector
-
-Fill in the following fields to configure the connector:
-
-- **Integration name**: A display name for your connector.
-- **API Key**: Your Claude API key from the [Anthropic console](https://console.anthropic.com/settings/keys).
-- **Workspace ID**: Your Claude workspace ID from the [Anthropic console](https://console.anthropic.com/settings/workspaces).
-
-</Step>
-
-<Step>
-
-## Set a system prompt
-
-You can create the agent in two ways:
-
-- **Create from prompt**: describe what you want the agent to do, and Novu generates a system prompt. You can also pick a preset template (Customer Support, Marketing, etc.).
-- **Create manually**: give a name and identifier and write the system prompt yourself.
-
-For a manual prompt, something like this works well:
-
-```text
-You are a helpful support agent for Acme Corp. Answer questions about
-our products, pricing, and account setup. Keep responses short and
-friendly. If you do not know the answer, say so and offer to connect
-the user with a human.
+```bash
+npx novu connect
 ```
 
-Click **Create Agent** when you are done.
+</Step>
+
+<Step>
+
+## Create an agent
+
+1. Choose where your agent runs. The CLI asks **Where do you want the agent to run?** Select an option and press **Enter**:
+    * **Demo credentials**: The fastest way to start. No Anthropic API key required (Novu handles it), with up to 10 conversations per month.
+    * **Claude Managed Agents**: Bring your own Anthropic API key.
+    * **AWS Claude Managed Agents**: Use your AWS Claude credentials (API key, region, and workspace ID).
+    For this quickstart, select **Demo credentials**.
+2. Describe your agent. Type a description of what you want the agent to do and press **Enter**.
+    ```text
+    Create an engineering assistant agent that checks Linear and GitHub for open issues, pending PR reviews, and review requests. It summarizes what needs attention, flags blockers and stale tickets, and posts a short daily standup digest. It keeps responses concise and links back to the relevant Linear issue or GitHub pull request.
+    ```
+    Novu will generate the agent for you, including its system prompt, tools, MCP servers, and skills based on your description.
+3. Review and create the agent. The CLI shows the generated agent for you to review. You can adjust any of the following fields before confirming:
+      * Name
+      * Identifier
+      * System prompt
+      * Tools
+      * MCP servers
+      * Skills
+      
+  If everything looks good, select **Create this agent** and press **Enter**.
+ 
+  If you want to change the description and regenerate, select **Regenerate from description** and repeat the previous step.
 
 </Step>
 
 <Step>
 
-## Connect a provider
+## Connect Slack
 
-1. On the agent setup page, click **Select provider**.
-2. Choose **Slack**.
-3. Follow the Slack setup steps in the dashboard:
-   - Generate a Slack App Configuration Token.
-   - Paste it in Novu and click **Create app**.
-   - Click **Install agent** to add the bot to your Slack workspace.
+The CLI prompts you: **pick a channel to connect this agent to.** Select **Slack** and press **Enter**.
+ 
+Novu will ask you to paste a Slack App Configuration Token. To get one:
+1. Open [https://api.slack.com/apps](https://api.slack.com/apps).
+2. Scroll to the bottom of the page.
+3. Under **App Configuration Tokens**, click **Generate Token**.
+4. Copy the access token, it starts with `xoxe.xoxp-`.
+5. Paste the token into the terminal and press **Enter**.
+    <Callout type="info">
+    The CLI sends the token to your Novu account once to create the Slack app, then discards it; the token isn't stored.
+    </Callout>
+6. Add the app to your workspace. After pasting the token, the CLI prompts you to add the app to your Slack workspace. Press **Enter** and follow the link to install the bot.
 
-<Callout type="info">
-The configuration token is used once to create the Slack app and is not stored by Novu.
-</Callout>
+Once installed, your agent is live and listening for messages in Slack.
 
 </Step>
 
@@ -85,20 +84,15 @@ The configuration token is used once to create the Slack app and is not stored b
 
 ## Send a message
 
-Open Slack and send a direct message to your new bot. Claude processes the message and the reply appears in the thread.
-
-You can also mention the bot in a channel where it has been added.
-
+Open Slack, where you'll see a message from your agent. Send it a direct message to get started. You'll then be prompted by the agent to connect your Linear and GitHub MCP servers, once you do, your agent is ready.
+ 
+You can also add and interact with the agent in any channel in the workspace.
+ 
+To manage your agent, add more channels, or view conversations from the Connect dashboard, create a Novu account at [connect.novu.co](https://connect.novu.co/).
+ 
 </Step>
 
 </Steps>
-
-## What to do next
-
-- **Enable MCP servers**: Give the agent access to tools like Linear, GitHub, or Notion from the agent settings page.
-- **Upload custom skills**: Add SKILL.md files to teach the agent domain-specific workflows.
-- **Connect more providers**: Add Microsoft Teams, email, or other providers from the agent setup page.
-- **View conversations**: Open the Activity Feed in the dashboard and switch to the Agent Conversations tab to see message history.
 
 ## Next steps
 
@@ -107,9 +101,9 @@ You can also mention the bot in a channel where it has been added.
     Learn about connectors, MCP servers, skills, and how conversations work.
   </Card>
   <Card icon={<Link />} href="/agents/managed-agent/configure-mcp-servers" title="Configure MCP servers">
-    Enable external tools for your managed agent.
+    Give your agent access to external tools like Linear, GitHub, or Notion.
   </Card>
   <Card icon={<MessagesSquare />} href="/agents/conversations" title="Conversation observability">
-    View and manage agent conversations in the dashboard.
+    View and manage agent conversations from the Novu Connect dashboard.
   </Card>
 </Cards>

--- a/content/docs/agents/managed-agent/quickstart.mdx
+++ b/content/docs/agents/managed-agent/quickstart.mdx
@@ -55,7 +55,7 @@ npx novu connect
       
   If everything looks good, select **Create this agent** and press **Enter**.
  
-  If you want to change the description and regenerate, select **Regenerate from description** and repeat the previous step.
+  If you want to change the description and regenerate, then select **Regenerate from description** and repeat the previous step.
 
 </Step>
 

--- a/content/docs/agents/managed-agent/quickstart.mdx
+++ b/content/docs/agents/managed-agent/quickstart.mdx
@@ -53,7 +53,7 @@ npx novu connect
       * MCP servers
       * Skills
       
-  If everything looks good, select **Create this agent** and press **Enter**.
+  If everything looks good, then select **Create this agent** and press **Enter**.
  
   If you want to change the description and regenerate, then select **Regenerate from description** and repeat the previous step.
 

--- a/content/docs/agents/managed-agent/quickstart.mdx
+++ b/content/docs/agents/managed-agent/quickstart.mdx
@@ -35,7 +35,7 @@ npx novu connect
 
 ## Create an agent
 
-1. Choose where your agent runs. The CLI asks **Where do you want the agent to run?** Select an option and press **Enter**:
+1. Choose where your agent runs. The CLI asks **Where do you want the agent to run?** , select an option and then press **Enter**:
     * **Demo credentials**: The fastest way to start. No Anthropic API key required (Novu handles it), with up to 10 conversations per month.
     * **Claude Managed Agents**: Bring your own Anthropic API key.
     * **AWS Claude Managed Agents**: Use your AWS Claude credentials (API key, region, and workspace ID).

--- a/content/docs/agents/meta.json
+++ b/content/docs/agents/meta.json
@@ -4,6 +4,7 @@
   "description": "Agents",
   "pages": [
     "---Get Started---",
+    "index",
     "get-started/what-is-aci",
     "get-started/mental-model",
     "get-started/agents-and-providers",

--- a/content/docs/platform/additional-resources/glossary.mdx
+++ b/content/docs/platform/additional-resources/glossary.mdx
@@ -17,6 +17,10 @@ If you have any questions or need further clarification on any of the terms list
 
 An `actor` refers to a user or subscriber who initiates actions that trigger events within the system. Each actor is uniquely identified by an "actorId," also known as "subscriberId". Actors hold user-related variables and can enhance notifications by allowing their avatars to be displayed.
 
+### Agent brain
+
+The agent brain is the system that decides how an agent responds. It can be powered by an LLM, custom code, a rules engine, a human-in-the-loop workflow, a managed agent platform, or a combination of systems. The agent brain is separate from the communication infrastructure that delivers messages across channels, which is handled by [ACI](/agents/get-started/what-is-aci).
+
 ### Channels
 
 Novu lets you send notifications across different communication mediums, including emails, in-app messages, push notifications, SMS, and chat. Each of these five communication mediums is referred to as a notification 'channel'.

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -172,7 +172,6 @@ export default async function middleware(request: NextRequest, event: NextFetchE
     '/platform/workflow/workflows.mdx': '/platform/workflow',
     '/docs/platform/workflow/layouts':
       '/platform/workflow/add-notification-content/channels-template-editors#email-layouts',
-
   };
 
   if (pathname in redirectMap) {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -173,8 +173,6 @@ export default async function middleware(request: NextRequest, event: NextFetchE
     '/docs/platform/workflow/layouts':
       '/platform/workflow/add-notification-content/channels-template-editors#email-layouts',
 
-    // Agents section landing
-    '/agents': '/agents/get-started/what-is-aci',
   };
 
   if (pathname in redirectMap) {


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Rewrote the ACI “What is” page with a clearer three-part flow and a more explicit “ACI handles vs what you control” breakdown.
  - Added a new Agents overview page with a conversation walkthrough, quickstart entry points, and related links.
  - Updated the managed agent quickstart to use a Novu CLI flow, including Slack setup and a faster “get a reply” path.
  - Refreshed agent documentation navigation entries.
- **Bug Fixes**
  - Adjusted Next.js middleware redirects by removing the `/agents` → `what-is-aci` mapping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR rewrites the agents documentation with client-facing language, adds a new `/agents` overview page (`index.mdx`), updates the managed agent quickstart to use the Novu CLI (`npx novu connect`), and removes the now-redundant `/agents` → `what-is-aci` middleware redirect.

- **New `index.mdx`**: Serves as the `/agents` landing page, explaining ACI's two concerns (communication infrastructure vs. agent intelligence) and providing entry points to both the managed agent and custom code agent paths.
- **Quickstart rewrite**: Replaces the dashboard-based flow with a CLI-driven flow; adds a Slack App Configuration Token walkthrough and a demo GIF.
- **`what-is-aci.mdx` refresh**: Replaces technical jargon with product-oriented language and restructures the three-part architecture explanation with bullet-list channel enumerations.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only documentation and a single redirect removal; no runtime logic is introduced.

All code changes are documentation content and a one-line redirect removal. The middleware change is safe: `/agents` is covered by `MARKDOWN_SECTIONS` so the catch-all redirect never fires, and `index.mdx` now correctly serves that route. The only new finding is a minor cross-link inconsistency in the "Start building" section of `what-is-aci.mdx`.

The "Start building" Quickstart card in `what-is-aci.mdx` still points to the custom code agent path while the new overview page promotes the managed agent CLI path — worth aligning before merge.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| content/docs/agents/get-started/what-is-aci.mdx | Rewrites the ACI explainer with client-facing language; minor inconsistency in the "Start building" section where the Quickstart card targets the custom code path while index.mdx promotes the managed agent CLI path. |
| content/docs/agents/index.mdx | New agents overview page added to serve /agents; links, structure, and conversation flow description look correct. Missing trailing newline (flagged in previous review). |
| content/docs/agents/managed-agent/quickstart.mdx | Quickstart rewritten around the Novu CLI (`npx novu connect`) flow; Slack token instructions are accurate. "Send a message" step is coupled to the engineering-assistant example description (flagged in a previous review). Missing trailing newline (flagged in previous review). |
| content/docs/agents/meta.json | Adds "index" as the first navigation entry under Get Started, correctly wiring index.mdx into the sidebar. |
| content/docs/platform/additional-resources/glossary.mdx | Adds "Agent brain" glossary entry with a link to the ACI page; definition is consistent with usage in index.mdx and what-is-aci.mdx. |
| src/middleware.ts | Removes the `/agents` → `what-is-aci` redirect; safe because `/agents` is already listed in MARKDOWN_SECTIONS so the catch-all platform-prefix redirect does not fire, and index.mdx now serves the route directly. |
| public/images/agents/quickstart/novu-connect-demo.gif | New demo GIF added and correctly referenced by the quickstart page. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User visits /agents] --> B{New index.mdx}
    B --> C[Overview: ACI explained]
    C --> D{Choose agent type}
    D --> E[Managed Agent\n/agents/managed-agent/quickstart]
    D --> F[Custom Code Agent\n/agents/custom-code-agent/quickstart]
    E --> G[npx novu connect]
    G --> H[Select: Demo credentials\nor Claude Managed Agents]
    H --> I[Describe agent]
    I --> J[Connect Slack\nSlack App Config Token]
    J --> K[Agent live in Slack]
    K --> L[Send DM to bot]
    L --> M[Reply via ACI bridge]
    M --> N[Persisted in Connect dashboard]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User visits /agents] --> B{New index.mdx}
    B --> C[Overview: ACI explained]
    C --> D{Choose agent type}
    D --> E[Managed Agent\n/agents/managed-agent/quickstart]
    D --> F[Custom Code Agent\n/agents/custom-code-agent/quickstart]
    E --> G[npx novu connect]
    G --> H[Select: Demo credentials\nor Claude Managed Agents]
    H --> I[Describe agent]
    I --> J[Connect Slack\nSlack App Config Token]
    J --> K[Agent live in Slack]
    K --> L[Send DM to bot]
    L --> M[Reply via ACI bridge]
    M --> N[Persisted in Connect dashboard]
```

</a>

<sub>Reviews (4): Last reviewed commit: ["Update index file"](https://github.com/novuhq/docs/commit/f379c4f3951bbc8b9fcbe20dc6806ecd485e4a35) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=37490307)</sub>

<!-- /greptile_comment -->