### PR TITLE
docs(agents): add "Pricing" page to agents docs

### DIFF
--- a/content/docs/agents/meta.json
+++ b/content/docs/agents/meta.json
@@ -16,6 +16,9 @@
     "...custom-code-agent",
 
     "---Observability---",
-    "conversations"
+    "conversations",
+
+    "---Pricing---",
+    "pricing"
   ]
 }

--- a/content/docs/agents/pricing.mdx
+++ b/content/docs/agents/pricing.mdx
@@ -1,0 +1,112 @@
+---
+title: "Pricing"
+pageTitle: 'Pricing'
+description: 'Plans, limits, and billing for Novu Connect (Agent Communication Infrastructure).'
+icon: CreditCard
+---
+
+import { ConnectPricingCalculator } from '@/components/agents/pricing-calculator';
+
+Novu Connect bills on your plan, the number of **active conversations** per billing cycle, and how many agents and channel connections you keep running. Agents are included in your current Novu subscription. You do not need a separate Connect subscription. Workflow run overage and agent conversation overage are billed separately.
+
+Every plan includes the same channels, agent providers, and core features. Plans differ in volume, retention, and team controls.
+
+## Plans
+
+| | Free | Pro | Team | Enterprise |
+| --- | --- | --- | --- | --- |
+| Price | $0 | $30 / mo | $250 / mo | Custom |
+| Active conversations | 100 | 1,000 | 5,000 | Custom |
+| Extra conversation | Not available | $0.02 | $0.015 | Custom |
+| Agents | 2 | 5 | 10 | Unlimited |
+| Channels | 2 | 5 | All available | All available |
+| Branding | Novu branding shown | Removable | Removable | Removable |
+| Custom email domain | No | No | Yes | Yes |
+| History | 24 hours | 7 days | 90 days | Custom |
+
+Free stops counting new conversations when you hit 100 until your billing cycle resets or you upgrade. Pro and Team bill overage at the rates above. Enterprise includes HIPAA BAA, SSO and SCIM, audit logs, and dedicated support. Contact [sales@novu.co](mailto:sales@novu.co) for Enterprise pricing.
+
+## Estimate your cost
+
+<ConnectPricingCalculator />
+
+## Active conversations
+
+An **active conversation** is a Connect thread where an agent is involved. You are billed once per billing cycle for that thread, no matter how many messages are exchanged while it stays active.
+
+In Connect, every conversation is **active**, **resolved**, or **reopened**. Resolving a conversation ends its active period for billing. If the user messages again and Connect reopens it, that counts as a new active conversation. For lifecycle details, refer to [Agent Conversations](/agents/conversations).
+
+### What counts
+
+1. A user starts a thread, or a resolved conversation is reopened.
+2. That counts as one active conversation for the current billing cycle.
+3. More messages in the same active thread do not add to the count.
+4. When the conversation is resolved, it stops being active.
+5. A later reopen starts a new active conversation.
+
+### Billing cycle comes first
+
+Your billing cycle is the main window for counting conversations. Retention limits and platform session rules only matter when they end sooner than your billing cycle.
+
+If a conversation starts at 11:00 AM today and your plan renews tomorrow at 7:00 AM, it counts only until 7:00 AM. It does not carry into the next cycle just because the thread is still open on the channel.
+
+Connect applies whichever limit ends first: billing cycle reset, plan history retention, or the platform's own session rules.
+
+### By platform
+
+Platforms handle threads differently. Connect maps each one to the same active, resolved, and reopened model.
+
+| Platform | One active conversation | New conversation starts when |
+| --- | --- | --- |
+| Slack | One DM or channel thread with the agent, even with many messages or participants | The conversation is resolved and reopened, or a new thread starts |
+| Microsoft Teams | One chat or channel thread with the agent | Same as Slack |
+| Email | One thread with the same subject and participants | The conversation is resolved and a later reply reopens it |
+| WhatsApp | One user chat within the 24-hour messaging window | The session expires and the user sends a new message |
+| Telegram | One chat with the bot | A new session starts after the previous one was resolved |
+| SMS | One back-and-forth with the same user on the same number | A new thread starts after the previous one was resolved |
+
+| Scenario | Billed as |
+| --- | --- |
+| 80 messages in one Slack DM all month | 1 active conversation |
+| Agent and six teammates in one Slack channel all week | 1 active conversation |
+| Email resolved on the 10th, reopened on the 20th (same cycle) | 2 active conversations |
+| WhatsApp 24-hour window expires, user replies the next day | 2 active conversations |
+| Activity in January, none in February | 1 in January, 0 in February |
+| One-way outbound email with no reply path | 1 active conversation |
+| Thread starts at 11:00 AM today, plan renews at 7:00 AM tomorrow | 1 in the current cycle, counted until 7:00 AM |
+
+## Agents and channels
+
+**Agents** are distinct personas or bots in your workspace. One agent on four channels is still one agent. Paused agents do not count.
+
+**Channels** are external connections: one Slack workspace, one WhatsApp number, one Telegram bot, or one email domain. Multiple Slack channels in the same workspace count as one connection.
+
+Agent and channel limits are capacity caps, not metered add-ons. At your limit, upgrade or pause an existing agent or channel.
+
+## Included on every plan
+
+- **Channels:** Email, Slack, Microsoft Teams, WhatsApp, Telegram, SMS
+- **Agent providers:** Managed Claude Code, AWS Bedrock, Google Vertex AI, Azure AI Foundry, Claude Platform on AWS, Mistral, LangChain and LangGraph, custom code
+- **Capabilities:** Identity resolution, tools and skills, MCP OAuth, credentials vault, shared context across channels, streaming, reactions, replies, actions, forms, cards
+
+## FAQ
+
+### What happens when I exceed my conversation limit?
+
+Pro and Team bill overage at $0.02 and $0.015 per extra conversation. Free is capped until your cycle resets or you upgrade. Enterprise uses committed volume.
+
+### What happens when I hit my agent or channel limit?
+
+You upgrade or disable an existing agent or channel. Connect does not meter agents or channels separately.
+
+### Are channels or agent providers limited to higher plans?
+
+No. Every channel and provider is on every plan. Plans differ in how many agents and connections you can run, plus team and security features.
+
+### Can I change plans without losing data?
+
+Yes. Agents, conversations, and connections stay in place. On downgrade, items above the new limit are paused, not deleted.
+
+### Is Connect HIPAA compliant?
+
+HIPAA BAAs are on Enterprise. Contact [sales@novu.co](mailto:sales@novu.co) if you need to route protected health information through Connect.

--- a/content/docs/agents/pricing.mdx
+++ b/content/docs/agents/pricing.mdx
@@ -9,9 +9,9 @@ import { ConnectPricingCalculator } from '@/components/agents/pricing-calculator
 
 Novu Connect bills on your plan, the number of **active conversations** per billing cycle, and how many agents and channel connections you keep running. Agents are included in your current Novu subscription. You do not need a separate Connect subscription. Workflow run overage and agent conversation overage are billed separately.
 
-Every plan includes the same channels, agent providers, and core features. Plans differ in volume, retention, and team controls.
-
 ## Plans
+
+Connect limits follow your Novu plan tier. The table below compares price, conversation volume, and the features that change between tiers.
 
 | | Free | Pro | Team | Enterprise |
 | --- | --- | --- | --- | --- |
@@ -28,11 +28,13 @@ Free stops counting new conversations when you hit 100 until your billing cycle 
 
 ## Estimate your cost
 
+Pick a plan and set your expected conversation volume to see how base price and overage add up for one billing cycle.
+
 <ConnectPricingCalculator />
 
 ## Active conversations
 
-An **active conversation** is a Connect thread where an agent is involved. You are billed once per billing cycle for that thread, no matter how many messages are exchanged while it stays active.
+This is the main unit Connect uses for billing. An **active conversation** is a thread where an agent is involved. You are billed once per billing cycle for that thread, no matter how many messages are exchanged while it stays active.
 
 In Connect, every conversation is **active**, **resolved**, or **reopened**. Resolving a conversation ends its active period for billing. If the user messages again and Connect reopens it, that counts as a new active conversation. For lifecycle details, refer to [Agent Conversations](/agents/conversations).
 
@@ -77,19 +79,25 @@ Platforms handle threads differently. Connect maps each one to the same active, 
 
 ## Agents and channels
 
+These limits control how much Connect infrastructure you can run in parallel. They are capacity caps, not metered add-ons.
+
 **Agents** are distinct personas or bots in your workspace. One agent on four channels is still one agent. Paused agents do not count.
 
 **Channels** are external connections: one Slack workspace, one WhatsApp number, one Telegram bot, or one email domain. Multiple Slack channels in the same workspace count as one connection.
 
-Agent and channel limits are capacity caps, not metered add-ons. At your limit, upgrade or pause an existing agent or channel.
+At your limit, upgrade or pause an existing agent or channel. Connect does not bill per extra agent or channel.
 
 ## Included on every plan
+
+Every tier ships with the same channels, agent providers, and core Connect capabilities. Plans differ in volume and team features, not in what you can build.
 
 - **Channels:** Email, Slack, Microsoft Teams, WhatsApp, Telegram, SMS
 - **Agent providers:** Managed Claude Code, AWS Bedrock, Google Vertex AI, Azure AI Foundry, Claude Platform on AWS, Mistral, LangChain and LangGraph, custom code
 - **Capabilities:** Identity resolution, tools and skills, MCP OAuth, credentials vault, shared context across channels, streaming, reactions, replies, actions, forms, cards
 
 ## FAQ
+
+Answers to common questions about conversation limits, plan changes, and compliance.
 
 ### What happens when I exceed my conversation limit?
 

--- a/content/docs/agents/pricing.mdx
+++ b/content/docs/agents/pricing.mdx
@@ -15,14 +15,14 @@ Connect limits follow your Novu plan tier. The table below compares price, conve
 
 | | Free | Pro | Team | Enterprise |
 | --- | --- | --- | --- | --- |
-| Price | $0 | $30 / mo | $250 / mo | Custom |
-| Active conversations | 100 | 1,000 | 5,000 | Custom |
-| Extra conversation | Not available | $0.02 | $0.015 | Custom |
-| Agents | 2 | 5 | 10 | Unlimited |
-| Channels | 2 | 5 | All available | All available |
-| Branding | Novu branding shown | Removable | Removable | Removable |
-| Custom email domain | No | No | Yes | Yes |
-| History | 24 hours | 7 days | 90 days | Custom |
+| **Price** | $0 | $30 / mo | $250 / mo | Custom |
+| **Active conversations** | 100 | 1,000 | 5,000 | Custom |
+| **Extra conversation** | Not available | $0.02 | $0.015 | Custom |
+| **Agents** | 2 | 5 | 10 | Unlimited |
+| **Channels** | 2 | 5 | All available | All available |
+| **Branding** | Novu branding shown | Removable | Removable | Removable |
+| **Custom email domain** | No | No | Yes | Yes |
+| **History** | 24 hours | 7 days | 90 days | Custom |
 
 Free stops counting new conversations when you hit 100 until your billing cycle resets or you upgrade. Pro and Team bill overage at the rates above. Enterprise includes HIPAA BAA, SSO and SCIM, audit logs, and dedicated support. Contact [sales@novu.co](mailto:sales@novu.co) for Enterprise pricing.
 
@@ -60,12 +60,11 @@ Platforms handle threads differently. Connect maps each one to the same active, 
 
 | Platform | One active conversation | New conversation starts when |
 | --- | --- | --- |
-| Slack | One DM or channel thread with the agent, even with many messages or participants | The conversation is resolved and reopened, or a new thread starts |
-| Microsoft Teams | One chat or channel thread with the agent | Same as Slack |
-| Email | One thread with the same subject and participants | The conversation is resolved and a later reply reopens it |
-| WhatsApp | One user chat within the 24-hour messaging window | The session expires and the user sends a new message |
-| Telegram | One chat with the bot | A new session starts after the previous one was resolved |
-| SMS | One back-and-forth with the same user on the same number | A new thread starts after the previous one was resolved |
+| **Slack** | One DM or channel thread with the agent, even with many messages or participants | The conversation is resolved and reopened, or a new thread starts |
+| **Microsoft Teams** | One chat or channel thread with the agent | Same as Slack |
+| **Email** | One thread with the same subject and participants | The conversation is resolved and a later reply reopens it |
+| **WhatsApp** | One user chat within the 24-hour messaging window | The session expires and the user sends a new message |
+| **Telegram** | One chat with the bot | A new session starts after the previous one was resolved |
 
 | Scenario | Billed as |
 | --- | --- |
@@ -91,7 +90,7 @@ At your limit, upgrade or pause an existing agent or channel. Connect does not b
 
 Every tier ships with the same channels, agent providers, and core Connect capabilities. Plans differ in volume and team features, not in what you can build.
 
-- **Channels:** Email, Slack, Microsoft Teams, WhatsApp, Telegram, SMS
+- **Channels:** Email, Slack, Microsoft Teams, WhatsApp, Telegram
 - **Agent providers:** Managed Claude Code, AWS Bedrock, Google Vertex AI, Azure AI Foundry, Claude Platform on AWS, Mistral, LangChain and LangGraph, custom code
 - **Capabilities:** Identity resolution, tools and skills, MCP OAuth, credentials vault, shared context across channels, streaming, reactions, replies, actions, forms, cards
 

--- a/src/components/agents/pricing-calculator.tsx
+++ b/src/components/agents/pricing-calculator.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { cn } from '@/lib/cn';
+
+type PlanId = 'free' | 'pro' | 'team';
+
+type Plan = {
+  id: PlanId;
+  name: string;
+  monthlyPrice: number;
+  includedConversations: number;
+  overageRate: number | null;
+  agents: number | 'Unlimited';
+  channels: string;
+};
+
+const PLANS: Plan[] = [
+  {
+    id: 'free',
+    name: 'Free',
+    monthlyPrice: 0,
+    includedConversations: 100,
+    overageRate: null,
+    agents: 2,
+    channels: '2',
+  },
+  {
+    id: 'pro',
+    name: 'Pro',
+    monthlyPrice: 30,
+    includedConversations: 1000,
+    overageRate: 0.02,
+    agents: 5,
+    channels: '5',
+  },
+  {
+    id: 'team',
+    name: 'Team',
+    monthlyPrice: 250,
+    includedConversations: 5000,
+    overageRate: 0.015,
+    agents: 10,
+    channels: 'All available',
+  },
+];
+
+const MAX_CONVERSATIONS = 20000;
+const FREE_TO_PRO_THRESHOLD = 300;
+const PRO_TEAM_TO_FREE_THRESHOLD = 100;
+
+function formatCurrency(value: number): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: value % 1 === 0 ? 0 : 2,
+    maximumFractionDigits: 2,
+  }).format(value);
+}
+
+function formatNumber(value: number): string {
+  return new Intl.NumberFormat('en-US').format(value);
+}
+
+export function ConnectPricingCalculator(): React.ReactElement {
+  const [selectedPlanId, setSelectedPlanId] = useState<PlanId>('pro');
+  const [conversations, setConversations] = useState(1500);
+
+  const selectedPlan = PLANS.find((plan) => plan.id === selectedPlanId) ?? PLANS[1];
+
+  const estimate = useMemo(() => {
+    const extraConversations = Math.max(0, conversations - selectedPlan.includedConversations);
+    const overageCost =
+      selectedPlan.overageRate === null ? 0 : extraConversations * selectedPlan.overageRate;
+    const total = selectedPlan.monthlyPrice + overageCost;
+    const isOverFreeLimit =
+      selectedPlan.id === 'free' && conversations > selectedPlan.includedConversations;
+
+    return {
+      extraConversations,
+      overageCost,
+      total,
+      isOverFreeLimit,
+    };
+  }, [conversations, selectedPlan]);
+
+  function handleConversationsChange(value: number): void {
+    const nextValue = Math.min(Math.max(0, value), MAX_CONVERSATIONS);
+
+    setConversations(nextValue);
+    setSelectedPlanId((currentPlanId) => {
+      if (currentPlanId === 'free' && nextValue > FREE_TO_PRO_THRESHOLD) {
+        return 'pro';
+      }
+
+      if (
+        (currentPlanId === 'pro' || currentPlanId === 'team') &&
+        nextValue < PRO_TEAM_TO_FREE_THRESHOLD
+      ) {
+        return 'free';
+      }
+
+      return currentPlanId;
+    });
+  }
+
+  return (
+    <div className="not-prose my-6 rounded-lg border bg-fd-card p-5 shadow-sm">
+      <div className="mb-5">
+        <h3 className="text-base font-medium text-fd-foreground">Estimate your monthly cost</h3>
+        <p className="mt-1 text-sm text-fd-muted-foreground">
+          Pick a plan and set how many active conversations you expect each billing cycle.
+        </p>
+      </div>
+
+      <div className="mb-6">
+        <p className="mb-2 text-sm font-medium text-fd-foreground">Plan</p>
+        <div className="grid gap-2 sm:grid-cols-3">
+          {PLANS.map((plan) => {
+            const isSelected = plan.id === selectedPlanId;
+
+            return (
+              <button
+                key={plan.id}
+                type="button"
+                onClick={() => setSelectedPlanId(plan.id)}
+                className={cn(
+                  'rounded-md border px-3 py-2 text-left transition-colors',
+                  isSelected
+                    ? 'border-[#4b73ec] bg-[#f3f6ff] dark:border-[#00d5ff] dark:bg-[#0f1a24]'
+                    : 'border-fd-border hover:border-fd-muted-foreground/40'
+                )}
+              >
+                <span className="block text-sm font-medium text-fd-foreground">{plan.name}</span>
+                <span className="block text-xs text-fd-muted-foreground">
+                  {plan.monthlyPrice === 0
+                    ? '$0 / month'
+                    : `${formatCurrency(plan.monthlyPrice)} / month`}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mb-6">
+        <div className="mb-2 flex items-end justify-between gap-3">
+          <label
+            htmlFor="connect-pricing-conversations"
+            className="text-sm font-medium text-fd-foreground"
+          >
+            Active conversations per billing cycle
+          </label>
+          <input
+            id="connect-pricing-conversations-input"
+            type="number"
+            min={0}
+            max={MAX_CONVERSATIONS}
+            value={conversations}
+            onChange={(event) => handleConversationsChange(Number(event.target.value))}
+            className="w-28 rounded-md border border-fd-border bg-fd-background px-2 py-1 text-right text-sm text-fd-foreground"
+          />
+        </div>
+        <input
+          id="connect-pricing-conversations"
+          type="range"
+          min={0}
+          max={MAX_CONVERSATIONS}
+          step={50}
+          value={conversations}
+          onChange={(event) => handleConversationsChange(Number(event.target.value))}
+          className="w-full accent-[#4b73ec] dark:accent-[#00d5ff]"
+        />
+        <div className="mt-1 flex justify-between text-xs text-fd-muted-foreground">
+          <span>0</span>
+          <span>{formatNumber(MAX_CONVERSATIONS)}</span>
+        </div>
+      </div>
+
+      <div className="rounded-md border border-fd-border bg-fd-background p-4">
+        <dl className="space-y-2 text-sm">
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-fd-muted-foreground">Plan price</dt>
+            <dd className="font-medium text-fd-foreground">
+              {formatCurrency(selectedPlan.monthlyPrice)}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-fd-muted-foreground">Included conversations</dt>
+            <dd className="font-medium text-fd-foreground">
+              {formatNumber(selectedPlan.includedConversations)}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-fd-muted-foreground">Extra conversations</dt>
+            <dd className="font-medium text-fd-foreground">
+              {formatNumber(estimate.extraConversations)}
+            </dd>
+          </div>
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-fd-muted-foreground">Overage charges</dt>
+            <dd className="font-medium text-fd-foreground">
+              {selectedPlan.overageRate === null
+                ? 'Not available on Free'
+                : formatCurrency(estimate.overageCost)}
+            </dd>
+          </div>
+          <div className="border-t border-fd-border pt-2">
+            <div className="flex items-center justify-between gap-4">
+              <dt className="font-medium text-fd-foreground">Estimated total</dt>
+              <dd className="text-lg font-semibold text-fd-foreground">
+                {formatCurrency(estimate.total)}
+              </dd>
+            </div>
+          </div>
+        </dl>
+
+        {estimate.isOverFreeLimit ? (
+          <p className="mt-3 text-sm text-fd-muted-foreground">
+            Free is capped at {formatNumber(selectedPlan.includedConversations)} active
+            conversations per billing cycle. Upgrade to Pro or Team to keep running, or wait for
+            your next cycle to reset.
+          </p>
+        ) : null}
+
+        {selectedPlan.overageRate !== null && estimate.extraConversations > 0 ? (
+          <p className="mt-3 text-sm text-fd-muted-foreground">
+            Overage is billed at {formatCurrency(selectedPlan.overageRate)} per extra conversation
+            on the {selectedPlan.name} plan.
+          </p>
+        ) : null}
+      </div>
+
+      <p className="mt-3 text-xs text-fd-muted-foreground">
+        Enterprise pricing is custom. For committed volume, HIPAA BAA, SSO, or SCIM, contact{' '}
+        <a href="mailto:sales@novu.co" className="text-fd-primary underline underline-offset-2">
+          sales@novu.co
+        </a>
+        .
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a new "Pricing" documentation page for Novu Connect under the agents section, along with an interactive `ConnectPricingCalculator` React component that lets users estimate monthly costs by plan and conversation volume.

- **`pricing.mdx`**: Comprehensive new page covering plan tiers, active conversation billing semantics, per-platform counting rules, and an FAQ section — all consistent with each other.
- **`pricing-calculator.tsx`**: Client component with plan selector, conversation slider/number input, and a live estimate breakdown. The `formatCurrency` helper caps at 2 decimal places, which silently rounds the Team plan's `$0.015` overage rate down to `$0.01` for users.
- **`meta.json`**: Registers the new page under a "Pricing" sidebar section in the agents navigation.

<h3>Confidence Score: 4/5</h3>

Safe to merge with one fix recommended: the Team plan overage rate displays as $0.01 instead of $0.015 in the calculator hint text.

The documentation content is accurate and well-structured. The calculator component works correctly for most scenarios, but `formatCurrency` with `maximumFractionDigits: 2` mis-displays the Team plan's three-decimal overage rate, showing users $0.01/conversation instead of the correct $0.015/conversation. This is live pricing information in a docs page, so the wrong rate is worth fixing before shipping.

src/components/agents/pricing-calculator.tsx — specifically the `formatCurrency` function and the auto-switch thresholds.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| src/components/agents/pricing-calculator.tsx | New interactive pricing calculator component. Contains a bug where `formatCurrency` with `maximumFractionDigits: 2` mis-displays the Team plan's $0.015 overage rate as $0.01. Also has a missing label association for the number input and auto-switching logic that can override explicit plan selection. |
| content/docs/agents/pricing.mdx | New pricing documentation page covering plans, active conversations, per-platform billing behaviour, and FAQ. Content is thorough and consistent with the pricing table data. |
| content/docs/agents/meta.json | Adds a 'Pricing' navigation section with the new pricing page to the agents sidebar. |

</details>

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User changes conversation count] --> B[Clamp to 0–20,000]
    B --> C[setConversations]
    B --> D{Current plan?}
    D -- free AND value > 300 --> E[Switch to Pro]
    D -- pro/team AND value < 100 --> F[Switch to Free]
    D -- otherwise --> G[Keep current plan]
    E & F & G --> H[Re-compute estimate via useMemo]
    H --> I{Free plan over limit?}
    I -- yes --> J[Show cap warning]
    I -- no --> K{Paid plan with overage?}
    K -- yes --> L[Show overage hint\n⚠️ formatCurrency 0.015 → $0.01]
    K -- no --> M[Show clean total]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User changes conversation count] --> B[Clamp to 0–20,000]
    B --> C[setConversations]
    B --> D{Current plan?}
    D -- free AND value > 300 --> E[Switch to Pro]
    D -- pro/team AND value < 100 --> F[Switch to Free]
    D -- otherwise --> G[Keep current plan]
    E & F & G --> H[Re-compute estimate via useMemo]
    H --> I{Free plan over limit?}
    I -- yes --> J[Show cap warning]
    I -- no --> K{Paid plan with overage?}
    K -- yes --> L[Show overage hint\n⚠️ formatCurrency 0.015 → $0.01]
    K -- no --> M[Show clean total]
```

</a>

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%203%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%203%0Asrc%2Fcomponents%2Fagents%2Fpricing-calculator.tsx%3A52-58%0A**%60formatCurrency%60%20truncates%20Team%20overage%20rate%20to%20wrong%20value**%0A%0A%60maximumFractionDigits%3A%202%60%20causes%20%60formatCurrency%280.015%29%60%20to%20render%20as%20%60%240.01%60%20instead%20of%20%60%240.015%60.%20In%20JavaScript%2C%20%600.015%60%20is%20stored%20as%20%600.01499999...%60%20in%20IEEE%20754%2C%20so%20rounding%20to%202%20decimal%20places%20floors%20to%20%60%240.01%60%20%E2%80%94%20a%2033%25%20understatement%20of%20the%20Team%20plan's%20per-conversation%20rate.%20This%20appears%20in%20the%20overage%20hint%20on%20line%20228%20when%20the%20Team%20plan%20is%20selected%20with%20extra%20conversations.%20%60maximumFractionDigits%60%20should%20be%20increased%20to%20%603%60%20to%20accommodate%20this%20rate.%0A%0A%23%23%23%20Issue%202%20of%203%0Asrc%2Fcomponents%2Fagents%2Fpricing-calculator.tsx%3A148-162%0A**Number%20input%20has%20no%20accessible%20label**%0A%0AThe%20%60%3Clabel%3E%60%20element's%20%60htmlFor%3D%22connect-pricing-conversations%22%60%20points%20to%20the%20range%20slider%2C%20but%20the%20numeric%20%60%3Cinput%3E%60%20has%20%60id%3D%22connect-pricing-conversations-input%22%60%20with%20no%20associated%20label.%20Screen%20readers%20will%20not%20announce%20the%20purpose%20of%20the%20number%20field%20when%20it%20receives%20focus.%0A%0A%23%23%23%20Issue%203%20of%203%0Asrc%2Fcomponents%2Fagents%2Fpricing-calculator.tsx%3A91-101%0A**Auto-switching%20overrides%20manual%20Team%20plan%20selection%20unexpectedly**%0A%0AWhen%20a%20user%20explicitly%20clicks%20Team%20and%20then%20drags%20the%20slider%20below%20100%2C%20the%20plan%20silently%20resets%20to%20Free.%20There's%20also%20a%20one-way%20threshold%20inconsistency%3A%20Free%20auto-promotes%20to%20Pro%20at%20300%20conversations%20but%20Pro%2FTeam%20never%20auto-promotes%20to%20Team%20%E2%80%94%20a%20user%20on%20the%20Pro%20plan%20with%205%2C001%20conversations%20%28above%20the%20Team%20threshold%29%20simply%20sees%20growing%20overage%20instead%20of%20being%20guided%20toward%20Team.%20Both%20behaviours%20could%20confuse%20users%20trying%20to%20compare%20plans.%0A%0A&pr=1134&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=3"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=3" height="20"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
src/components/agents/pricing-calculator.tsx:52-58
**`formatCurrency` truncates Team overage rate to wrong value**

`maximumFractionDigits: 2` causes `formatCurrency(0.015)` to render as `$0.01` instead of `$0.015`. In JavaScript, `0.015` is stored as `0.01499999...` in IEEE 754, so rounding to 2 decimal places floors to `$0.01` — a 33% understatement of the Team plan's per-conversation rate. This appears in the overage hint on line 228 when the Team plan is selected with extra conversations. `maximumFractionDigits` should be increased to `3` to accommodate this rate.

### Issue 2 of 3
src/components/agents/pricing-calculator.tsx:148-162
**Number input has no accessible label**

The `<label>` element's `htmlFor="connect-pricing-conversations"` points to the range slider, but the numeric `<input>` has `id="connect-pricing-conversations-input"` with no associated label. Screen readers will not announce the purpose of the number field when it receives focus.

### Issue 3 of 3
src/components/agents/pricing-calculator.tsx:91-101
**Auto-switching overrides manual Team plan selection unexpectedly**

When a user explicitly clicks Team and then drags the slider below 100, the plan silently resets to Free. There's also a one-way threshold inconsistency: Free auto-promotes to Pro at 300 conversations but Pro/Team never auto-promotes to Team — a user on the Pro plan with 5,001 conversations (above the Team threshold) simply sees growing overage instead of being guided toward Team. Both behaviours could confuse users trying to compare plans.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(agents): enhance pricing documentat..."](https://github.com/novuhq/docs/commit/b871a65b3334d8e18645421ab8e774889c4fe7ff) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39305737)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->